### PR TITLE
RemoveExpireRows Generating Excessive Error Messages

### DIFF
--- a/src/main/Hangfire.Storage.SQLite/SQLiteDistributedLock.cs
+++ b/src/main/Hangfire.Storage.SQLite/SQLiteDistributedLock.cs
@@ -162,7 +162,7 @@ namespace Hangfire.Storage.SQLite
 
                 if (!isLockAcquired)
                 {
-                    throw new DistributedLockTimeoutException($"Could not place a lock on the resource \'{_resource}\': The lock request timed out.");
+                    throw new DistributedLockTimeoutException(_resource);
                 }
             }
             catch (DistributedLockTimeoutException ex)


### PR DESCRIPTION
This PR aims to cleanup an issue where RemoveExpireRows will often generate an error log even though code is there explicitly to handle the situation where the DistributedLockTimeoutException is generated with the DistributedLockKey.

[https://github.com/raisedapp/Hangfire.Storage.SQLite/blob/53afcdfd8401ff1d437f266e5f3722aeae8353f4/src/main/Hangfire.Storage.SQLite/ExpirationManager.cs#L113-L125](Lines in reference)