### PR TITLE
Revisit the logic for SQLiteDistributedLock (see #38)

### DIFF
--- a/src/main/Hangfire.Storage.SQLite/Entities/DistributedLock.cs
+++ b/src/main/Hangfire.Storage.SQLite/Entities/DistributedLock.cs
@@ -24,6 +24,12 @@ namespace Hangfire.Storage.SQLite.Entities
         public string Resource { get; set; }
 
         /// <summary>
+        /// The owner key for this resource.
+        /// Prevents race conditions and changes to locks that are owned by other entities.
+        /// </summary>
+        public string ResourceKey { get; set; }
+
+        /// <summary>
         /// The timestamp for when the lock expires.
         /// This is used if the lock is not maintained or 
         /// cleaned up by the owner (e.g. process was shut down).


### PR DESCRIPTION
- introduce a key for the lock (to express ownership) 
- Acquire() should either insert or fail (but never update), and needs to Cleanup in each loop because locks might expire while waiting 
- Release() should check ownership (it should never release a lock that we don't own) 
- Heartbeat should check ownership (it should never extend a lock that we don't own)