### PR TITLE
Heartbeat method should throw a BackgroundServerGoneException when no servers exist for an update

### DIFF
--- a/src/main/Hangfire.Storage.SQLite/HangfireSQLiteConnection.cs
+++ b/src/main/Hangfire.Storage.SQLite/HangfireSQLiteConnection.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using Hangfire.Common;
 using Hangfire.Server;
@@ -330,10 +329,15 @@ namespace Hangfire.Storage.SQLite
 
             var server = DbContext.HangfireServerRepository.FirstOrDefault(_ => _.Id == serverId);
             if (server == null)
-                return;
+	            throw new BackgroundServerGoneException();
 
             server.LastHeartbeat = DateTime.UtcNow;
-            DbContext.Database.Update(server);
+            var affected = DbContext.Database.Update(server);
+            
+            if (affected == 0)
+            {
+	            throw new BackgroundServerGoneException();
+            }
         }
 
         public override void RemoveServer(string serverId)

--- a/src/test/Hangfire.Storage.SQLite.Test/SQLiteConnectionFacts.cs
+++ b/src/test/Hangfire.Storage.SQLite.Test/SQLiteConnectionFacts.cs
@@ -8,7 +8,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using Xunit;
 
@@ -627,6 +626,13 @@ namespace Hangfire.Storage.SQLite.Test
             });
         }
 
+        [Fact, CleanDatabase]
+        public void Heartbeat_ThrowsBackgroundServerGoneException_WhenGivenServerDoesNotExist()
+        {
+	        UseConnection((database, connection) => Assert.Throws<BackgroundServerGoneException>(
+		        () => connection.Heartbeat(Guid.NewGuid().ToString())));
+        }
+        
         [Fact, CleanDatabase]
         public void Heartbeat_ThrowsAnException_WhenServerIdIsNull()
         {


### PR DESCRIPTION
As of Hangfire version 1.7.0 the storage [`Heartbeat`](https://github.com/raisedapp/Hangfire.Storage.SQLite/blob/7d0960b05c299393b1b05aa9fef4ac50214f07c9/src/main/Hangfire.Storage.SQLite/HangfireSQLiteConnection.cs#L324) method should throw a `BackgroundServerGoneException` when no servers respond to a heartbeat in order to allow [Hangfire.Server.ServerHeartbeatProcess](https://github.com/HangfireIO/Hangfire/blob/b5fabd9e544bdfcbf4eabfb8bde33ba1e30ac4d1/src/Hangfire.Core/Server/ServerHeartbeatProcess.cs#L65) to automatically restart the failed servers.

This should fix issues with server(s) potentially disappearing and resulting with no jobs being processed.

[Example](https://github.com/HangfireIO/Hangfire/blob/b5fabd9e544bdfcbf4eabfb8bde33ba1e30ac4d1/src/Hangfire.SqlServer/SqlServerConnection.cs#L483) of an implementation in the official Hangfire repo.