### PR TITLE
Per-Request SQLiteConnection, Pooling, Threading shenanigans

### DIFF
--- a/src/main/Hangfire.Storage.SQLite/HangfireDbContext.cs
+++ b/src/main/Hangfire.Storage.SQLite/HangfireDbContext.cs
@@ -7,28 +7,6 @@ using System.Threading;
 
 namespace Hangfire.Storage.SQLite
 {
-    internal class PooledHangfireDbContext : HangfireDbContext
-    {
-        private readonly Action<PooledHangfireDbContext> _onDispose;
-        public bool PhaseOut { get; set; }
-
-        internal PooledHangfireDbContext(SQLiteConnection connection, Action<PooledHangfireDbContext> onDispose, string prefix = "hangfire") 
-            : base(connection, prefix)
-        {
-            _onDispose = onDispose;
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            if (PhaseOut)
-            {
-                base.Dispose(disposing);
-                return;
-            }
-            _onDispose(this);
-        }
-    }
-    
     /// <summary>
     /// Represents SQLite database context for Hangfire
     /// </summary>

--- a/src/main/Hangfire.Storage.SQLite/HangfireDbContext.cs
+++ b/src/main/Hangfire.Storage.SQLite/HangfireDbContext.cs
@@ -144,7 +144,6 @@ namespace Hangfire.Storage.SQLite
                 Database?.Dispose();
                 Database = null;
             }
-            GC.SuppressFinalize(this);
         }
         
         public void Dispose()

--- a/src/main/Hangfire.Storage.SQLite/HangfireSQLiteConnection.cs
+++ b/src/main/Hangfire.Storage.SQLite/HangfireSQLiteConnection.cs
@@ -38,6 +38,12 @@ namespace Hangfire.Storage.SQLite
             _queueProviders = queueProviders ?? throw new ArgumentNullException(nameof(queueProviders));
         }
 
+        public override void Dispose()
+        {
+            DbContext.Dispose();
+            base.Dispose();
+        }
+
         public override IDisposable AcquireDistributedLock(string resource, TimeSpan timeout)
         {
             return new SQLiteDistributedLock($"HangFire:{resource}", timeout, DbContext, _storageOptions);

--- a/src/main/Hangfire.Storage.SQLite/PooledHangfireDbContext.cs
+++ b/src/main/Hangfire.Storage.SQLite/PooledHangfireDbContext.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using SQLite;
+
+namespace Hangfire.Storage.SQLite
+{
+    internal class PooledHangfireDbContext : HangfireDbContext
+    {
+        private readonly Action<PooledHangfireDbContext> _onDispose;
+        public bool PhaseOut { get; set; }
+
+        internal PooledHangfireDbContext(SQLiteConnection connection, Action<PooledHangfireDbContext> onDispose, string prefix = "hangfire") 
+            : base(connection, prefix)
+        {
+            _onDispose = onDispose ?? throw new ArgumentNullException(nameof(onDispose));
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            _onDispose(this);
+            if (PhaseOut)
+            {
+                base.Dispose(disposing);
+            }
+        }
+    }
+}

--- a/src/main/Hangfire.Storage.SQLite/SQLiteDbConnectionFactory.cs
+++ b/src/main/Hangfire.Storage.SQLite/SQLiteDbConnectionFactory.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using SQLite;
+
+namespace Hangfire.Storage.SQLite
+{
+    public class SQLiteDbConnectionFactory
+    {
+        private readonly Func<SQLiteConnection> _getConnection;
+
+        public SQLiteDbConnectionFactory(Func<SQLiteConnection> getConnection)
+        {
+            _getConnection = getConnection;
+        }
+
+        public SQLiteConnection Create()
+        {
+            return _getConnection();
+        }
+    }
+}

--- a/src/main/Hangfire.Storage.SQLite/SQLiteDistributedLock.cs
+++ b/src/main/Hangfire.Storage.SQLite/SQLiteDistributedLock.cs
@@ -162,11 +162,11 @@ namespace Hangfire.Storage.SQLite
             }
             catch (DistributedLockTimeoutException ex)
             {
-                throw ex;
+                throw;
             }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             }
         }
 
@@ -185,7 +185,7 @@ namespace Hangfire.Storage.SQLite
             }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             }
         }
 

--- a/src/main/Hangfire.Storage.SQLite/SQLiteMonitoringApi.cs
+++ b/src/main/Hangfire.Storage.SQLite/SQLiteMonitoringApi.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using Hangfire.Common;
 using Hangfire.States;
 using Hangfire.Storage.Monitoring;
@@ -12,25 +11,28 @@ namespace Hangfire.Storage.SQLite
 {
     public class SQLiteMonitoringApi : IMonitoringApi
     {
-        private readonly HangfireDbContext _dbContext;
+        private readonly SQLiteStorage _storage;
 
         private readonly PersistentJobQueueProviderCollection _queueProviders;
 
         /// <summary>
         /// 
         /// </summary>
-        /// <param name="database"></param>
+        /// <param name="storage"></param>
         /// <param name="queueProviders"></param>
-        public SQLiteMonitoringApi(HangfireDbContext database, PersistentJobQueueProviderCollection queueProviders)
+        public SQLiteMonitoringApi(SQLiteStorage storage, PersistentJobQueueProviderCollection queueProviders)
         {
-            _dbContext = database;
+            _storage = storage;
             _queueProviders = queueProviders;
         }
 
         private T UseConnection<T>(Func<HangfireDbContext, T> action)
         {
-            var result = action(_dbContext);
-            return result;
+            using (var dbContext = _storage.CreateAndOpenConnection())
+            {
+                var result = action(dbContext);
+                return result;
+            }
         }
 
         private JobList<TDto> GetJobs<TDto>(HangfireDbContext connection, int from, int count, string stateName, Func<JobDetailedDto, Job, Dictionary<string, string>, TDto> selector)

--- a/src/main/Hangfire.Storage.SQLite/SQLiteStorage.cs
+++ b/src/main/Hangfire.Storage.SQLite/SQLiteStorage.cs
@@ -11,6 +11,7 @@ namespace Hangfire.Storage.SQLite
         private readonly string _databasePath;
 
         private readonly SQLiteDbConnectionFactory _dbConnectionFactory;
+
         private readonly SQLiteStorageOptions _storageOptions;
         private ConcurrentQueue<PooledHangfireDbContext> _dbContextPool = new ConcurrentQueue<PooledHangfireDbContext>();
 
@@ -71,8 +72,7 @@ namespace Hangfire.Storage.SQLite
 
         public override IMonitoringApi GetMonitoringApi()
         {
-            var dbContext = CreateAndOpenConnection();
-            return new SQLiteMonitoringApi(dbContext, QueueProviders);
+            return new SQLiteMonitoringApi(this, QueueProviders);
         }
 
         /// <summary>
@@ -112,12 +112,14 @@ namespace Hangfire.Storage.SQLite
         }
 
         private bool _disposed;
+
         public void Dispose()
         {
             if (_disposed)
             {
                 throw new ObjectDisposedException(nameof(SQLiteStorage));
             }
+
             foreach (var dbContext in _dbContextPool)
             {
                 dbContext.PhaseOut = true;

--- a/src/main/Hangfire.Storage.SQLite/SQLiteStorage.cs
+++ b/src/main/Hangfire.Storage.SQLite/SQLiteStorage.cs
@@ -1,21 +1,35 @@
 ﻿using Hangfire.Server;
 using SQLite;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Threading;
 using Hangfire.Logging;
+using Hangfire.Storage.SQLite.Entities;
 
 namespace Hangfire.Storage.SQLite
 {
+    public class SQLiteDbConnectionFactory
+    {
+        private readonly Func<SQLiteConnection> _getConnection;
+
+        public SQLiteDbConnectionFactory(Func<SQLiteConnection> getConnection)
+        {
+            _getConnection = getConnection;
+        }
+
+        public SQLiteConnection Create()
+        {
+            return _getConnection();
+        }
+    }
+
     public class SQLiteStorage : JobStorage
     {
         private readonly string _connectionString;
 
+        private readonly SQLiteDbConnectionFactory _dbConnectionFactory;
         private readonly SQLiteStorageOptions _storageOptions;
-
-        /// <summary>
-        /// Database context
-        /// </summary>
-        public HangfireDbContext Connection { get; }
 
         /// <summary>
         /// Queue providers collection
@@ -37,44 +51,47 @@ namespace Hangfire.Storage.SQLite
         /// <param name="databasePath">SQLite connection string</param>
         /// <param name="storageOptions">Storage options</param>
         public SQLiteStorage(string databasePath, SQLiteStorageOptions storageOptions)
-            : this(new SQLiteConnection(
-                    string.IsNullOrWhiteSpace(databasePath) ? throw new ArgumentNullException(nameof(databasePath)) : databasePath,
-                    SQLiteOpenFlags.ReadWrite | SQLiteOpenFlags.Create | SQLiteOpenFlags.FullMutex,
-                    storeDateTimeAsTicks: true
-                ), storageOptions)
+            : this(new SQLiteDbConnectionFactory(() => new SQLiteConnection(
+                string.IsNullOrWhiteSpace(databasePath) ? throw new ArgumentNullException(nameof(databasePath)) : databasePath,
+                SQLiteOpenFlags.ReadWrite | SQLiteOpenFlags.Create | SQLiteOpenFlags.FullMutex,
+                storeDateTimeAsTicks: true
+            ) {BusyTimeout = TimeSpan.FromSeconds(10)}), storageOptions)
         {
         }
 
         /// <summary>
         /// Constructs Job Storage by database connection string and options
         /// </summary>
-        /// <param name="dbConnection">SQLite connection</param>
+        /// <param name="dbConnectionFactory">Factory that creates SQLite connections</param>
         /// <param name="storageOptions">Storage options</param>
-        public SQLiteStorage(SQLiteConnection dbConnection, SQLiteStorageOptions storageOptions)
+        public SQLiteStorage(SQLiteDbConnectionFactory dbConnectionFactory, SQLiteStorageOptions storageOptions)
         {
-            if (dbConnection == null)
-            {
-                throw new ArgumentNullException(nameof(dbConnection));
-            }
-
+            _dbConnectionFactory = dbConnectionFactory ?? throw new ArgumentNullException(nameof(dbConnectionFactory));
             _storageOptions = storageOptions ?? throw new ArgumentNullException(nameof(storageOptions));
-
-            Connection = new HangfireDbContext(dbConnection, storageOptions.Prefix);
-            Connection.Init(_storageOptions);
 
             var defaultQueueProvider = new SQLiteJobQueueProvider(_storageOptions);
             QueueProviders = new PersistentJobQueueProviderCollection(defaultQueueProvider);
+
+            using (var dbContext = CreateAndOpenConnection())
+            {
+                // Use this to initialize the database as soon as possible
+                // in case of error, the user will immediately get an exception at startup
+            }
         }
 
         public override IStorageConnection GetConnection()
         {
-            return new HangfireSQLiteConnection(Connection, _storageOptions, QueueProviders);
+            var dbContext = CreateAndOpenConnection();
+            return new HangfireSQLiteConnection(dbContext, _storageOptions, QueueProviders);
         }
 
         public override IMonitoringApi GetMonitoringApi()
         {
-            return new SQLiteMonitoringApi(Connection, QueueProviders);
+            var dbContext = CreateAndOpenConnection();
+            return new SQLiteMonitoringApi(dbContext, QueueProviders);
         }
+
+        private readonly ConcurrentQueue<PooledHangfireDbContext> _dbContextPool = new ConcurrentQueue<PooledHangfireDbContext>();
 
         /// <summary>
         /// Opens connection to database
@@ -82,7 +99,14 @@ namespace Hangfire.Storage.SQLite
         /// <returns>Database context</returns>
         public HangfireDbContext CreateAndOpenConnection()
         {
-            return Connection;
+            if (_dbContextPool.TryDequeue(out var dbContext))
+            {
+                return dbContext;
+            }
+
+            dbContext = new PooledHangfireDbContext(_dbConnectionFactory.Create(), ctx => _dbContextPool.Enqueue(ctx), _storageOptions.Prefix);
+            dbContext.Init(_storageOptions);
+            return dbContext;
         }
 
         /// <summary>

--- a/src/main/Hangfire.Storage.SQLite/SQLiteStorage.cs
+++ b/src/main/Hangfire.Storage.SQLite/SQLiteStorage.cs
@@ -53,7 +53,7 @@ namespace Hangfire.Storage.SQLite
         public SQLiteStorage(string databasePath, SQLiteStorageOptions storageOptions)
             : this(new SQLiteDbConnectionFactory(() => new SQLiteConnection(
                 string.IsNullOrWhiteSpace(databasePath) ? throw new ArgumentNullException(nameof(databasePath)) : databasePath,
-                SQLiteOpenFlags.ReadWrite | SQLiteOpenFlags.Create | SQLiteOpenFlags.FullMutex,
+                SQLiteOpenFlags.ReadWrite | SQLiteOpenFlags.Create | SQLiteOpenFlags.NoMutex,
                 storeDateTimeAsTicks: true
             ) {BusyTimeout = TimeSpan.FromSeconds(10)}), storageOptions)
         {

--- a/src/main/Hangfire.Storage.SQLite/SQLiteStorageExtensions.cs
+++ b/src/main/Hangfire.Storage.SQLite/SQLiteStorageExtensions.cs
@@ -52,20 +52,20 @@ namespace Hangfire.Storage.SQLite
         /// 
         /// </summary>
         /// <param name="configuration"></param>
-        /// <param name="connection">Existing connection to use</param>
+        /// <param name="connectionFactory">connection factory to use</param>
         /// <param name="options"></param>
         /// <returns></returns>
         /// <exception cref="ArgumentNullException"></exception>
         public static IGlobalConfiguration<SQLiteStorage> UseSQLiteStorage(
             [NotNull] this IGlobalConfiguration configuration,
-            [NotNull] global::SQLite.SQLiteConnection connection,
+            [NotNull] SQLiteDbConnectionFactory connectionFactory,
             SQLiteStorageOptions options = null)
         {
             if (configuration == null) throw new ArgumentNullException(nameof(configuration));
-            if (connection == null) throw new ArgumentNullException(nameof(connection));
+            if (connectionFactory == null) throw new ArgumentNullException(nameof(connectionFactory));
             if (options == null) options = new SQLiteStorageOptions();
 
-            var storage = new SQLiteStorage(connection, options);
+            var storage = new SQLiteStorage(connectionFactory, options);
 
             return configuration.UseStorage(storage);
         }

--- a/src/main/Hangfire.Storage.SQLite/SQLiteStorageOptions.cs
+++ b/src/main/Hangfire.Storage.SQLite/SQLiteStorageOptions.cs
@@ -42,6 +42,7 @@ namespace Hangfire.Storage.SQLite
                 {
                     throw new ArgumentException(message, nameof(value));
                 }
+
                 if (value != value.Duration())
                 {
                     throw new ArgumentException(message, nameof(value));
@@ -65,6 +66,7 @@ namespace Hangfire.Storage.SQLite
                 {
                     throw new ArgumentException(message, nameof(value));
                 }
+
                 if (value != value.Duration())
                 {
                     throw new ArgumentException(message, nameof(value));
@@ -95,7 +97,8 @@ namespace Hangfire.Storage.SQLite
         public TimeSpan CountersAggregateInterval { get; set; }
 
         /// <summary>
-        /// Set AutoVacuum Mode In SQLite
+        /// Set AutoVacuum Mode In SQLite.
+        /// Defaults to <see cref="AutoVacuum.NONE"/>.
         /// </summary>
         public AutoVacuum AutoVacuumSelected { get; set; } = AutoVacuum.NONE;
 
@@ -106,6 +109,10 @@ namespace Hangfire.Storage.SQLite
             INCREMENTAL = 2
         }
 
+        /// <summary>
+        /// Set journal_mode in SQLite.
+        /// Defaults to <see cref="JournalModes.DELETE"/>.
+        /// </summary>
         public JournalModes JournalMode { get; set; } = JournalModes.DELETE;
 
         public enum JournalModes
@@ -117,5 +124,10 @@ namespace Hangfire.Storage.SQLite
             WAL,
             OFF
         }
+
+        /// <summary>
+        /// Limits the amount of pooled SQLiteConnections.
+        /// </summary>
+        public int PoolSize { get; set; } = 10;
     }
 }

--- a/src/main/Hangfire.Storage.SQLite/SQLiteStorageOptions.cs
+++ b/src/main/Hangfire.Storage.SQLite/SQLiteStorageOptions.cs
@@ -111,9 +111,9 @@ namespace Hangfire.Storage.SQLite
 
         /// <summary>
         /// Set journal_mode in SQLite.
-        /// Defaults to <see cref="JournalModes.DELETE"/>.
+        /// Defaults to <see cref="JournalModes.WAL"/>.
         /// </summary>
-        public JournalModes JournalMode { get; set; } = JournalModes.DELETE;
+        public JournalModes JournalMode { get; set; } = JournalModes.WAL;
 
         public enum JournalModes
         {
@@ -128,6 +128,6 @@ namespace Hangfire.Storage.SQLite
         /// <summary>
         /// Limits the amount of pooled SQLiteConnections.
         /// </summary>
-        public int PoolSize { get; set; } = 10;
+        public int PoolSize { get; set; } = 20;
     }
 }

--- a/src/main/Hangfire.Storage.SQLite/SQLiteWriteOnlyTransaction.cs
+++ b/src/main/Hangfire.Storage.SQLite/SQLiteWriteOnlyTransaction.cs
@@ -330,7 +330,7 @@ namespace Hangfire.Storage.SQLite
                     {
                         _.Database.Rollback();
                         
-                        throw ex;
+                        throw;
                     }
                 }
             });        

--- a/src/samples/WebSample/Program.cs
+++ b/src/samples/WebSample/Program.cs
@@ -16,12 +16,7 @@ services.AddHangfire(configuration => configuration
     .UseSimpleAssemblyNameTypeSerializer()
     .UseRecommendedSerializerSettings()
     .UseSQLiteStorage("Hangfire.db",
-        new SQLiteStorageOptions()
-        {
-            AutoVacuumSelected = SQLiteStorageOptions.AutoVacuum.FULL,
-            JournalMode = SQLiteStorageOptions.JournalModes.WAL,
-            JobExpirationCheckInterval = TimeSpan.FromSeconds(30)
-        })
+        new SQLiteStorageOptions() { AutoVacuumSelected = SQLiteStorageOptions.AutoVacuum.FULL, JobExpirationCheckInterval = TimeSpan.FromSeconds(30) })
     .UseHeartbeatPage(checkInterval: TimeSpan.FromSeconds(10))
     .UseJobsLogger());
 services.AddHangfireServer();

--- a/src/samples/WebSample/Program.cs
+++ b/src/samples/WebSample/Program.cs
@@ -16,7 +16,12 @@ services.AddHangfire(configuration => configuration
     .UseSimpleAssemblyNameTypeSerializer()
     .UseRecommendedSerializerSettings()
     .UseSQLiteStorage("Hangfire.db",
-        new SQLiteStorageOptions() { AutoVacuumSelected = SQLiteStorageOptions.AutoVacuum.FULL, JobExpirationCheckInterval = TimeSpan.FromSeconds(30) })
+        new SQLiteStorageOptions()
+        {
+            AutoVacuumSelected = SQLiteStorageOptions.AutoVacuum.FULL,
+            JournalMode = SQLiteStorageOptions.JournalModes.WAL,
+            JobExpirationCheckInterval = TimeSpan.FromSeconds(30)
+        })
     .UseHeartbeatPage(checkInterval: TimeSpan.FromSeconds(10))
     .UseJobsLogger());
 services.AddHangfireServer();

--- a/src/test/Hangfire.Storage.SQLite.Test/ExpirationManagerFacts.cs
+++ b/src/test/Hangfire.Storage.SQLite.Test/ExpirationManagerFacts.cs
@@ -31,7 +31,7 @@ namespace Hangfire.Storage.SQLite.Test
         [Fact]
         public void Execute_RemovesOutdatedRecords()
         {
-            var connection = _storage.Connection;
+            using var connection = _storage.CreateAndOpenConnection();
             CreateExpirationEntries(connection, DateTime.UtcNow.AddMonths(-1));
             var manager = CreateManager();
             manager.Execute(_token);
@@ -41,7 +41,7 @@ namespace Hangfire.Storage.SQLite.Test
         [Fact]
         public void Execute_DoesNotRemoveEntries_WithNoExpirationTimeSet()
         {
-            var connection = _storage.Connection;
+            using var connection = _storage.CreateAndOpenConnection();
             CreateExpirationEntries(connection, null);
             var manager = CreateManager();
             manager.Execute(_token);
@@ -51,7 +51,7 @@ namespace Hangfire.Storage.SQLite.Test
         [Fact]
         public void Execute_DoesNotRemoveEntries_WithFreshExpirationTime()
         {
-            var connection = _storage.Connection;
+            using var connection = _storage.CreateAndOpenConnection();
             CreateExpirationEntries(connection, DateTime.UtcNow.AddMonths(1));
             var manager = CreateManager();
             manager.Execute(_token);
@@ -61,7 +61,7 @@ namespace Hangfire.Storage.SQLite.Test
         [Fact]
         public void Execute_Processes_CounterTable()
         {
-            var connection = _storage.Connection;
+            using var connection = _storage.CreateAndOpenConnection();
             connection.Database.Insert(new Counter
             {
                 Id = Guid.NewGuid().ToString(),
@@ -78,7 +78,7 @@ namespace Hangfire.Storage.SQLite.Test
         [Fact]
         public void Execute_Processes_JobTable()
         {
-            var connection = _storage.Connection;
+            using var connection = _storage.CreateAndOpenConnection();
             connection.Database.Insert(new HangfireJob()
             {
                 InvocationData = "",
@@ -95,7 +95,7 @@ namespace Hangfire.Storage.SQLite.Test
         [Fact]
         public void Execute_Processes_ListTable()
         {
-            var connection = _storage.Connection;
+            using var connection = _storage.CreateAndOpenConnection();
             connection.Database.Insert(new HangfireList()
             {
                 Key = "key",
@@ -112,7 +112,7 @@ namespace Hangfire.Storage.SQLite.Test
         [Fact]
         public void Execute_Processes_SetTable()
         {
-            var connection = _storage.Connection;
+            using var connection = _storage.CreateAndOpenConnection();
             connection.Database.Insert(new Set
             {
                 Key = "key",
@@ -131,7 +131,7 @@ namespace Hangfire.Storage.SQLite.Test
         [Fact]
         public void Execute_Processes_HashTable()
         {
-            var connection = _storage.Connection;
+            using var connection = _storage.CreateAndOpenConnection();
             connection.Database.Insert(new Hash()
             {
                 Key = "key",
@@ -151,7 +151,7 @@ namespace Hangfire.Storage.SQLite.Test
         [Fact]
         public void Execute_Processes_AggregatedCounterTable()
         {
-            var connection = _storage.Connection;
+            using var connection = _storage.CreateAndOpenConnection();
             connection.Database.Insert(new AggregatedCounter
             {
                 Key = "key",

--- a/src/test/Hangfire.Storage.SQLite.Test/SQLiteConnectionFacts.cs
+++ b/src/test/Hangfire.Storage.SQLite.Test/SQLiteConnectionFacts.cs
@@ -1525,11 +1525,9 @@ namespace Hangfire.Storage.SQLite.Test
         }
         private void UseConnection(Action<HangfireDbContext, HangfireSQLiteConnection> action)
         {
-            var database = ConnectionUtils.CreateConnection();
-            using (var connection = new HangfireSQLiteConnection(database, _providers))
-            {
-                action(database, connection);
-            }
+            using var database = ConnectionUtils.CreateConnection();
+            using var connection = new HangfireSQLiteConnection(database, _providers);
+            action(database, connection);
         }
 
         public static void SampleMethod(string arg)

--- a/src/test/Hangfire.Storage.SQLite.Test/SQLiteDistributedLockFacts.cs
+++ b/src/test/Hangfire.Storage.SQLite.Test/SQLiteDistributedLockFacts.cs
@@ -104,19 +104,25 @@ namespace Hangfire.Storage.SQLite.Test
         [Fact]
         public void Ctor_WaitForLock_SignaledAtLockRelease()
         {
-            UseConnection(database =>
+            var storage = ConnectionUtils.CreateStorage();
+            using var mre = new ManualResetEventSlim();
+            var t = new Thread(() =>
             {
-                var t = new Thread(() =>
+                UseConnection(database =>
                 {
                     using (new SQLiteDistributedLock("resource1", TimeSpan.Zero, database, new SQLiteStorageOptions()))
                     {
+                        mre.Set();
                         Thread.Sleep(TimeSpan.FromSeconds(3));
                     }
-                });
+                }, storage);
+            });
+            UseConnection(database =>
+            {
                 t.Start();
 
                 // Wait just a bit to make sure the above lock is acuired
-                Thread.Sleep(TimeSpan.FromSeconds(1));
+                mre.Wait(TimeSpan.FromSeconds(5));
 
                 // Record when we try to aquire the lock
                 var startTime = DateTime.UtcNow;
@@ -124,21 +130,22 @@ namespace Hangfire.Storage.SQLite.Test
                 {
                     Assert.InRange(DateTime.UtcNow - startTime, TimeSpan.Zero, TimeSpan.FromSeconds(5));
                 }
-            });
+            }, storage);
         }
 
         [Fact]
         public void Ctor_WaitForLock_OnlySingleLockCanBeAcquired()
         {
-            var connection = ConnectionUtils.CreateConnection();
             var numThreads = 10;
             long concurrencyCounter = 0;
-            var manualResetEvent = new ManualResetEventSlim();
+            using var manualResetEvent = new ManualResetEventSlim();
             var success = new bool[numThreads];
-
+            var storage = ConnectionUtils.CreateStorage();
+            
             // Spawn multiple threads to race each other.
             var threads = Enumerable.Range(0, numThreads).Select(i => new Thread(() =>
             {
+                using var connection = storage.CreateAndOpenConnection();
                 // Wait for the start signal.
                 manualResetEvent.Wait();
 
@@ -224,9 +231,9 @@ namespace Hangfire.Storage.SQLite.Test
             });
         }
 
-        private static void UseConnection(Action<HangfireDbContext> action)
+        private static void UseConnection(Action<HangfireDbContext> action, SQLiteStorage storage = null)
         {
-            var connection = ConnectionUtils.CreateConnection();
+            using var connection = storage?.CreateAndOpenConnection() ?? ConnectionUtils.CreateConnection();
             action(connection);
         }
     }

--- a/src/test/Hangfire.Storage.SQLite.Test/SQLiteFetchedJobFacts.cs
+++ b/src/test/Hangfire.Storage.SQLite.Test/SQLiteFetchedJobFacts.cs
@@ -155,7 +155,7 @@ namespace Hangfire.Storage.SQLite.Test
 
         private static void UseConnection(Action<HangfireDbContext> action)
         {
-            var connection = ConnectionUtils.CreateConnection();
+            using var connection = ConnectionUtils.CreateConnection();
             action(connection);
         }
     }

--- a/src/test/Hangfire.Storage.SQLite.Test/SQLiteJobQueueFacts.cs
+++ b/src/test/Hangfire.Storage.SQLite.Test/SQLiteJobQueueFacts.cs
@@ -333,7 +333,7 @@ namespace Hangfire.Storage.SQLite.Test
 
         private static void UseConnection(Action<HangfireDbContext> action)
         {
-            var connection = ConnectionUtils.CreateConnection();
+            using var connection = ConnectionUtils.CreateConnection();
             action(connection);
         }
     }

--- a/src/test/Hangfire.Storage.SQLite.Test/SQLiteMonitoringApiFacts.cs
+++ b/src/test/Hangfire.Storage.SQLite.Test/SQLiteMonitoringApiFacts.cs
@@ -282,7 +282,7 @@ namespace Hangfire.Storage.SQLite.Test
 
         private void UseMonitoringApi(Action<HangfireDbContext, SQLiteMonitoringApi> action)
         {
-            var database = ConnectionUtils.CreateConnection();
+            using var database = ConnectionUtils.CreateConnection();
             var connection = new SQLiteMonitoringApi(database, _providers);
             action(database, connection);
         }

--- a/src/test/Hangfire.Storage.SQLite.Test/SQLiteMonitoringApiFacts.cs
+++ b/src/test/Hangfire.Storage.SQLite.Test/SQLiteMonitoringApiFacts.cs
@@ -282,9 +282,10 @@ namespace Hangfire.Storage.SQLite.Test
 
         private void UseMonitoringApi(Action<HangfireDbContext, SQLiteMonitoringApi> action)
         {
-            using var database = ConnectionUtils.CreateConnection();
-            var connection = new SQLiteMonitoringApi(database, _providers);
-            action(database, connection);
+            using var storage = ConnectionUtils.CreateStorage();
+            var connection = new SQLiteMonitoringApi(storage, _providers);
+            using var dbContext = storage.CreateAndOpenConnection();
+            action(dbContext, connection);
         }
 
         private HangfireJob CreateJobInState(HangfireDbContext database, string stateName, Func<HangfireJob, HangfireJob> visitor = null)

--- a/src/test/Hangfire.Storage.SQLite.Test/SQLiteWriteOnlyTransactionFacts.cs
+++ b/src/test/Hangfire.Storage.SQLite.Test/SQLiteWriteOnlyTransactionFacts.cs
@@ -911,7 +911,7 @@ namespace Hangfire.Storage.SQLite.Test
 
         private void UseConnection(Action<HangfireDbContext> action)
         {
-            HangfireDbContext connection = ConnectionUtils.CreateConnection();
+            using var connection = ConnectionUtils.CreateConnection();
             action(connection);
         }
 

--- a/src/test/Hangfire.Storage.SQLite.Test/Utils/ConnectionUtils.cs
+++ b/src/test/Hangfire.Storage.SQLite.Test/Utils/ConnectionUtils.cs
@@ -15,11 +15,13 @@ namespace Hangfire.Storage.SQLite.Test.Utils
         public static SQLiteStorage CreateStorage(SQLiteStorageOptions storageOptions)
         {
             // See SQLite Docs: https://www.sqlite.org/c3ref/c_open_autoproxy.html
-            const SQLiteOpenFlags SQLITE_OPEN_MEMORY = (SQLiteOpenFlags) 0x00000080;
+            // const SQLiteOpenFlags SQLITE_OPEN_MEMORY = (SQLiteOpenFlags) 0x00000080;
             const SQLiteOpenFlags SQLITE_OPEN_URI = (SQLiteOpenFlags) 0x00000040;
             const SQLiteOpenFlags flags = // open the database in memory
                 // SQLITE_OPEN_MEMORY |
-                // for whatever reason, if we don't use URI-mode, shared in-memory databases dont work.
+                // SQLiteOpenFlags.SharedCache |
+                // for whatever reason, if we don't use URI-mode,
+                // shared in-memory databases dont work properly.
                 SQLITE_OPEN_URI |
                 // open the database in read/write mode
                 SQLiteOpenFlags.ReadWrite |

--- a/src/test/Hangfire.Storage.SQLite.Test/Utils/ConnectionUtils.cs
+++ b/src/test/Hangfire.Storage.SQLite.Test/Utils/ConnectionUtils.cs
@@ -16,25 +16,37 @@ namespace Hangfire.Storage.SQLite.Test.Utils
         {
             // See SQLite Docs: https://www.sqlite.org/c3ref/c_open_autoproxy.html
             const SQLiteOpenFlags SQLITE_OPEN_MEMORY = (SQLiteOpenFlags) 0x00000080;
-
+            const SQLiteOpenFlags SQLITE_OPEN_URI = (SQLiteOpenFlags) 0x00000040;
             const SQLiteOpenFlags flags = // open the database in memory
-                SQLITE_OPEN_MEMORY |
+                // SQLITE_OPEN_MEMORY |
+                // for whatever reason, if we don't use URI-mode, shared in-memory databases dont work.
+                SQLITE_OPEN_URI |
                 // open the database in read/write mode
                 SQLiteOpenFlags.ReadWrite |
                 // create the database if it doesn't exist
                 SQLiteOpenFlags.Create |
                 // enable multi-threaded database access
-                SQLiteOpenFlags.SharedCache;
+                SQLiteOpenFlags.NoMutex;
 
-            var connection = new SQLiteConnection($"hangfire_{Guid.NewGuid():n}.db",
-                flags,
-                storeDateTimeAsTicks: true);
-            return new SQLiteStorage(connection, storageOptions);
+            var dbId = $"file:hangfire_{Guid.NewGuid():n}.db?mode=memory&cache=shared";
+            return new SQLiteStorage(new SQLiteDbConnectionFactory(() =>
+                    new SQLiteConnection(dbId,
+                        flags,
+                        storeDateTimeAsTicks: true)
+                    {
+                        BusyTimeout = TimeSpan.FromSeconds(10),
+                    }),
+                storageOptions);
         }
 
+        /// <summary>
+        /// Only use this if you have a single thread.
+        /// For multi-threaded tests, use <see cref="CreateStorage()"/> directly and
+        /// then call <see cref="SQLiteStorage.CreateAndOpenConnection"/> per Thread.
+        /// </summary>
         public static HangfireDbContext CreateConnection()
         {
-            return CreateStorage().Connection;
+            return CreateStorage().CreateAndOpenConnection();
         }
     }
 }


### PR DESCRIPTION
This PR brings in a bunch of changes and smaller threading optimizations/fixes

- Instead of passing in a `SQLiteConnection`, we now use a `SQLiteDbConnectionFactory`
  - this is only a Api breaking change on develop at this point in time
- `HangfireDbContext` is now pooled by adding `PooledHangfireDbContext`
  - The Pool has an configurable Limit of, by default, `20` pooled connections (`SQLiteStorageOptions.PoolSize`)
- The default `JournalMode` is now `WAL` as it is much better suited for concurrent access than traditional rollback journal
- `SQLiteMonitoringApi` now uses a (pooled-)connection per call to `UseConnection` as the interface does not allow for Disposing, thus would leak Connections otherwise.
- `ExpirationManager` uses a pooled connection per `Execute`
- `SQLiteDistributedLock` & `SQLiteWriteOnlyTransaction` re-throw exceptions without discarding the Stacktrace (`throw ex;` -> `throw;`)

Tests:
- Concurrent Tests now use a **Connection per Thread**, to resemble the expected use of the library.  
  Hangfire always grabs a connection using `Get(ReadOnly)Connection` and disposes it in a per-execution basis, it doesn't share the connection with multiple threads.
- Added a bunch of `using`-statements
- Tests now mostly use `storage.GetConnection` or `storage.CreateAndOpenConnection()`
- `SQLiteDistributedLockFacts.Ctor_WaitForLock_SignaledAtLockRelease` now uses a `ManualResetEventSlim` to signal a taken lock instead of randomly waiting for a second and just _assuming_ that the lock was taken.