### PR TITLE
fixes #68 & #69 Refactor DistributedLock

### DIFF
--- a/src/main/Hangfire.Storage.SQLite/ExpirationManager.cs
+++ b/src/main/Hangfire.Storage.SQLite/ExpirationManager.cs
@@ -105,10 +105,8 @@ namespace Hangfire.Storage.SQLite
 
             try
             {
-                var _lock = new SQLiteDistributedLock(DistributedLockKey, DefaultLockTimeout,
-                    db, db.StorageOptions);
-
-                using (_lock)
+                using (SQLiteDistributedLock.Acquire(DistributedLockKey, DefaultLockTimeout,
+                           db, db.StorageOptions))
                 {
                     rowsAffected = db.Database.Execute(deleteScript);
                 }

--- a/src/main/Hangfire.Storage.SQLite/HangfireSQLiteConnection.cs
+++ b/src/main/Hangfire.Storage.SQLite/HangfireSQLiteConnection.cs
@@ -47,7 +47,7 @@ namespace Hangfire.Storage.SQLite
         public override IDisposable AcquireDistributedLock(string resource, TimeSpan timeout)
         {
             return Retry.Twice((_) =>
-                new SQLiteDistributedLock($"HangFire:{resource}", timeout, DbContext, _storageOptions)
+                SQLiteDistributedLock.Acquire($"HangFire:{resource}", timeout, DbContext, _storageOptions)
             );
         }
 


### PR DESCRIPTION
- remove re-entrancy (fixes #68)
- pause heartbeat timer while processing
- update expiration using SQL Update statement in a single step
- Added Heartbeat event (for testing)
- if we no longer own the lock, we immediately dispose the heartbeat timer (fixes #69)