### PR TITLE
V0.4.2

### DIFF
--- a/src/main/Hangfire.Storage.SQLite/ExpirationManager.cs
+++ b/src/main/Hangfire.Storage.SQLite/ExpirationManager.cs
@@ -105,10 +105,8 @@ namespace Hangfire.Storage.SQLite
 
             try
             {
-                var _lock = new SQLiteDistributedLock(DistributedLockKey, DefaultLockTimeout,
-                    db, db.StorageOptions);
-
-                using (_lock)
+                using (SQLiteDistributedLock.Acquire(DistributedLockKey, DefaultLockTimeout,
+                           db, db.StorageOptions))
                 {
                     rowsAffected = db.Database.Execute(deleteScript);
                 }

--- a/src/main/Hangfire.Storage.SQLite/Hangfire.Storage.SQLite.csproj
+++ b/src/main/Hangfire.Storage.SQLite/Hangfire.Storage.SQLite.csproj
@@ -21,7 +21,11 @@
     <Description>An Alternative SQLite Storage for Hangfire</Description>
     <PackageReleaseNotes>
       0.4.2
-      - Stability and retry enhancements introduced by: Daniel Lindblom
+      -remove re-entrancy (fixes SQLiteDistributedLock doesn't play right with async #68). Thanks to @kirides
+      -pause heartbeat timer while processing. Thanks to @kirides
+      -update expiration using SQL Update statement in a single step. Thanks to @kirides
+      -Added Heartbeat event (for testing). Thanks to @kirides
+      -if we no longer own the lock, we immediately dispose the heartbeat timer (fixes Unable to update heartbeat - still happening in .NET 6.0 #69). Thanks to @kirides
     </PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>

--- a/src/main/Hangfire.Storage.SQLite/Hangfire.Storage.SQLite.csproj
+++ b/src/main/Hangfire.Storage.SQLite/Hangfire.Storage.SQLite.csproj
@@ -7,7 +7,7 @@
     <TargetFrameworks>netstandard2.0;net48</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>
-    <Version>0.4.1</Version>
+    <Version>0.4.2</Version>
     <Authors>RaisedApp</Authors>
     <Company>RaisedApp</Company>
     <Copyright>Copyright © 2019 - Present</Copyright>
@@ -20,7 +20,7 @@
     <title>Hangfire Storage SQLite</title>    
     <Description>An Alternative SQLite Storage for Hangfire</Description>
     <PackageReleaseNotes>
-      0.4.1
+      0.4.2
       - Stability and retry enhancements introduced by: Daniel Lindblom
     </PackageReleaseNotes>
   </PropertyGroup>

--- a/src/main/Hangfire.Storage.SQLite/HangfireSQLiteConnection.cs
+++ b/src/main/Hangfire.Storage.SQLite/HangfireSQLiteConnection.cs
@@ -47,7 +47,7 @@ namespace Hangfire.Storage.SQLite
         public override IDisposable AcquireDistributedLock(string resource, TimeSpan timeout)
         {
             return Retry.Twice((_) =>
-                new SQLiteDistributedLock($"HangFire:{resource}", timeout, DbContext, _storageOptions)
+                SQLiteDistributedLock.Acquire($"HangFire:{resource}", timeout, DbContext, _storageOptions)
             );
         }
 

--- a/src/main/Hangfire.Storage.SQLite/SQLiteStorage.cs
+++ b/src/main/Hangfire.Storage.SQLite/SQLiteStorage.cs
@@ -14,6 +14,24 @@ namespace Hangfire.Storage.SQLite
         private readonly SQLiteDbConnectionFactory _dbConnectionFactory;
 
         private readonly SQLiteStorageOptions _storageOptions;
+
+        private readonly Dictionary<string, bool> _features = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase)
+        {
+            { "Storage.ExtendedApi", false },
+            { "Job.Queue", true },
+            { "Connection.GetUtcDateTime", false },
+            { "Connection.BatchedGetFirstByLowestScoreFromSet", false },
+            { "Connection.GetSetContains", true },
+            { "Connection.GetSetCount.Limited", false },
+            { "BatchedGetFirstByLowestScoreFromSet", false },
+            { "Transaction.AcquireDistributedLock", true },
+            { "Transaction.CreateJob", true },
+            { "Transaction.SetJobParameter", true },
+            { "TransactionalAcknowledge:InMemoryFetchedJob", false },
+            { "Monitoring.DeletedStateGraphs", false },
+            { "Monitoring.AwaitingJobs", false }
+        };
+
         private ConcurrentQueue<PooledHangfireDbContext> _dbContextPool = new ConcurrentQueue<PooledHangfireDbContext>();
 
         /// <summary>
@@ -111,6 +129,15 @@ namespace Hangfire.Storage.SQLite
             {
                 dbContext.PhaseOut = true;
             }
+        }
+
+        public override bool HasFeature(string featureId)
+        {
+            if (featureId == null) throw new ArgumentNullException(nameof(featureId));
+
+            return _features.TryGetValue(featureId, out var isSupported)
+                ? isSupported
+                : base.HasFeature(featureId);
         }
 
         /// <summary>

--- a/src/samples/WebSample/Program.cs
+++ b/src/samples/WebSample/Program.cs
@@ -18,7 +18,10 @@ services.AddHangfire(configuration => configuration
     .UseSQLiteStorage("Hangfire.db")
     .UseHeartbeatPage(checkInterval: TimeSpan.FromSeconds(10))
     .UseJobsLogger());
-services.AddHangfireServer();
+services.AddHangfireServer(options =>
+{
+    options.Queues = new[] { "test_queue_1", "default" };
+});
 
 var app = builder.Build();
 
@@ -26,5 +29,13 @@ app.UseHangfireDashboard(string.Empty);
 
 RecurringJob.AddOrUpdate("TaskMethod()", (TaskSample t) => t.TaskMethod(), Cron.Minutely);
 RecurringJob.AddOrUpdate("TaskMethod2()", (TaskSample t) => t.TaskMethod2(null), Cron.Minutely);
+
+var t = app.Services.GetService<IBackgroundJobClient>();
+t.Enqueue(queue: "test_queue_1", methodCall: () => Console.WriteLine("Testing......"));
+t.Enqueue(queue: "test_queue_1", methodCall: () => Console.WriteLine("Testing......"));
+t.Enqueue(queue: "test_queue_1", methodCall: () => Console.WriteLine("Testing......"));
+t.Enqueue(queue: "test_queue_1", methodCall: () => Console.WriteLine("Testing......"));
+t.Enqueue(queue: "test_queue_1", methodCall: () => Console.WriteLine("Testing......"));
+t.Enqueue(queue: "test_queue_1", methodCall: () => Console.WriteLine("Testing......"));
 
 app.Run();


### PR DESCRIPTION
0.4.2
-remove re-entrancy (fixes SQLiteDistributedLock doesn't play right with async #68). Thanks to @kirides
-pause heartbeat timer while processing. Thanks to @kirides
-update expiration using SQL Update statement in a single step. Thanks to @kirides
-Added Heartbeat event (for testing). Thanks to @kirides
-if we no longer own the lock, we immediately dispose the heartbeat timer (fixes Unable to update heartbeat - still happening in .NET 6.0 #69). Thanks to @kirides