### PR TITLE
- #73 - implement a few of the missing features

### DIFF
--- a/src/main/Hangfire.Storage.SQLite/Assembly.cs
+++ b/src/main/Hangfire.Storage.SQLite/Assembly.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Hangfire.Storage.SQLite.Test")]

--- a/src/main/Hangfire.Storage.SQLite/PersistentJobQueueProviderCollection.cs
+++ b/src/main/Hangfire.Storage.SQLite/PersistentJobQueueProviderCollection.cs
@@ -52,8 +52,8 @@ namespace Hangfire.Storage.SQLite
         /// <returns></returns>
         public IPersistentJobQueueProvider GetProvider(string queue)
         {
-            return _providersByQueue.ContainsKey(queue)
-                ? _providersByQueue[queue]
+            return _providersByQueue.TryGetValue(queue, out var value)
+                ? value
                 : _defaultProvider;
         }
 

--- a/src/main/Hangfire.Storage.SQLite/SQLiteDistributedLock.cs
+++ b/src/main/Hangfire.Storage.SQLite/SQLiteDistributedLock.cs
@@ -83,6 +83,7 @@ namespace Hangfire.Storage.SQLite
 
             _completed = true;
             _heartbeatTimer?.Dispose();
+            _heartbeatTimer = null;
             Release();
         }
 
@@ -184,7 +185,14 @@ namespace Hangfire.Storage.SQLite
                         Logger.ErrorFormat("Unable to update heartbeat on the resource '{0}'. The resource is not locked or is locked by another owner.", _resource);
 
                         // if we no longer have a lock, stop the heartbeat immediately
-                        _heartbeatTimer?.Dispose();
+                        try
+                        {
+                            _heartbeatTimer?.Dispose();
+                        }
+                        catch (ObjectDisposedException)
+                        {
+                            // well, already disposed?
+                        }
                         return;
                     }
                 }

--- a/src/main/Hangfire.Storage.SQLite/SQLiteStorage.cs
+++ b/src/main/Hangfire.Storage.SQLite/SQLiteStorage.cs
@@ -77,6 +77,7 @@ namespace Hangfire.Storage.SQLite
 
             using (var dbContext = CreateAndOpenConnection())
             {
+                dbContext.Migrate();
                 _databasePath = dbContext.Database.DatabasePath;
                 // Use this to initialize the database as soon as possible
                 // in case of error, the user will immediately get an exception at startup

--- a/src/main/Hangfire.Storage.SQLite/SQLiteStorage.cs
+++ b/src/main/Hangfire.Storage.SQLite/SQLiteStorage.cs
@@ -15,21 +15,21 @@ namespace Hangfire.Storage.SQLite
 
         private readonly SQLiteStorageOptions _storageOptions;
 
-        private readonly Dictionary<string, bool> _features = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase)
+        private static readonly Dictionary<string, bool> _features = new Dictionary<string, bool>(StringComparer.OrdinalIgnoreCase)
         {
-            { "Storage.ExtendedApi", false },
-            { "Job.Queue", true },
-            { "Connection.GetUtcDateTime", false },
-            { "Connection.BatchedGetFirstByLowestScoreFromSet", false },
-            { "Connection.GetSetContains", true },
-            { "Connection.GetSetCount.Limited", false },
-            { "BatchedGetFirstByLowestScoreFromSet", false },
-            { "Transaction.AcquireDistributedLock", true },
-            { "Transaction.CreateJob", true },
-            { "Transaction.SetJobParameter", true },
-            { "TransactionalAcknowledge:InMemoryFetchedJob", false },
-            { "Monitoring.DeletedStateGraphs", false },
-            { "Monitoring.AwaitingJobs", false }
+            { JobStorageFeatures.ExtendedApi, true },
+            { JobStorageFeatures.JobQueueProperty, true },
+            { JobStorageFeatures.Connection.GetUtcDateTime, true },
+            { JobStorageFeatures.Connection.BatchedGetFirstByLowest, true },
+            { "BatchedGetFirstByLowestScoreFromSet", true }, // ^-- legacy name?
+            { JobStorageFeatures.Connection.GetSetContains, true },
+            { JobStorageFeatures.Connection.LimitedGetSetCount, true },
+            { JobStorageFeatures.Transaction.AcquireDistributedLock, true },
+            { JobStorageFeatures.Transaction.CreateJob, false }, // NOTE: implement SQLiteWriteOnlyTransaction.CreateJob(...)
+            { JobStorageFeatures.Transaction.SetJobParameter, false }, // NOTE: implement SQLiteWriteOnlyTransaction.SetJobParameter(...)
+            { JobStorageFeatures.Transaction.RemoveFromQueue(typeof(SQLiteFetchedJob)), false }, // NOTE: implement SQLiteWriteOnlyTransaction.RemoveFromQueue(...)
+            { JobStorageFeatures.Monitoring.DeletedStateGraphs, false },
+            { JobStorageFeatures.Monitoring.AwaitingJobs, false }
         };
 
         private ConcurrentQueue<PooledHangfireDbContext> _dbContextPool = new ConcurrentQueue<PooledHangfireDbContext>();

--- a/src/test/Hangfire.Storage.SQLite.Test/CountersAggregatorFacts.cs
+++ b/src/test/Hangfire.Storage.SQLite.Test/CountersAggregatorFacts.cs
@@ -1,18 +1,16 @@
 using Hangfire.Storage.SQLite.Entities;
-using Hangfire.Storage.SQLite.Test.Utils;
 using System;
 using System.Threading;
 using Xunit;
 
 namespace Hangfire.Storage.SQLite.Test
 {
-    public class CountersAggregatorFacts
+    public class CountersAggregatorFacts : SqliteInMemoryTestBase
     {
         [Fact]
         public void CountersAggregatorExecutesProperly()
         {
-            var storage = ConnectionUtils.CreateStorage();
-            using (var connection = (HangfireSQLiteConnection)storage.GetConnection())
+            using (var connection = (HangfireSQLiteConnection)Storage.GetConnection())
             {
                 // Arrange
                 connection.DbContext.Database.Insert(new Counter
@@ -23,7 +21,7 @@ namespace Hangfire.Storage.SQLite.Test
                     ExpireAt = DateTime.UtcNow.AddHours(1)
                 });
 
-                var aggregator = new CountersAggregator(storage, TimeSpan.Zero);
+                var aggregator = new CountersAggregator(Storage, TimeSpan.Zero);
                 var cts = new CancellationTokenSource();
                 cts.Cancel();
 

--- a/src/test/Hangfire.Storage.SQLite.Test/ExpirationManagerFacts.cs
+++ b/src/test/Hangfire.Storage.SQLite.Test/ExpirationManagerFacts.cs
@@ -1,5 +1,4 @@
 using Hangfire.Storage.SQLite.Entities;
-using Hangfire.Storage.SQLite.Test.Utils;
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -7,17 +6,14 @@ using Xunit;
 
 namespace Hangfire.Storage.SQLite.Test
 {
-    public class ExpirationManagerFacts
+    public class ExpirationManagerFacts : SqliteInMemoryTestBase
     {
-        private readonly SQLiteStorage _storage;
-
         private readonly CancellationToken _token;
         private static PersistentJobQueueProviderCollection _queueProviders;
 
         public ExpirationManagerFacts()
         {
-            _storage = ConnectionUtils.CreateStorage();
-            _queueProviders = _storage.QueueProviders;
+            _queueProviders = Storage.QueueProviders;
 
             _token = new CancellationToken(true);
         }
@@ -31,7 +27,7 @@ namespace Hangfire.Storage.SQLite.Test
         [Fact]
         public void Execute_RemovesOutdatedRecords()
         {
-            using var connection = _storage.CreateAndOpenConnection();
+            using var connection = Storage.CreateAndOpenConnection();
             CreateExpirationEntries(connection, DateTime.UtcNow.AddMonths(-1));
             var manager = CreateManager();
             manager.Execute(_token);
@@ -41,7 +37,7 @@ namespace Hangfire.Storage.SQLite.Test
         [Fact]
         public void Execute_DoesNotRemoveEntries_WithNoExpirationTimeSet()
         {
-            using var connection = _storage.CreateAndOpenConnection();
+            using var connection = Storage.CreateAndOpenConnection();
             CreateExpirationEntries(connection, null);
             var manager = CreateManager();
             manager.Execute(_token);
@@ -51,7 +47,7 @@ namespace Hangfire.Storage.SQLite.Test
         [Fact]
         public void Execute_DoesNotRemoveEntries_WithFreshExpirationTime()
         {
-            using var connection = _storage.CreateAndOpenConnection();
+            using var connection = Storage.CreateAndOpenConnection();
             CreateExpirationEntries(connection, DateTime.UtcNow.AddMonths(1));
             var manager = CreateManager();
             manager.Execute(_token);
@@ -61,7 +57,7 @@ namespace Hangfire.Storage.SQLite.Test
         [Fact]
         public void Execute_Processes_CounterTable()
         {
-            using var connection = _storage.CreateAndOpenConnection();
+            using var connection = Storage.CreateAndOpenConnection();
             connection.Database.Insert(new Counter
             {
                 Id = Guid.NewGuid().ToString(),
@@ -78,7 +74,7 @@ namespace Hangfire.Storage.SQLite.Test
         [Fact]
         public void Execute_Processes_JobTable()
         {
-            using var connection = _storage.CreateAndOpenConnection();
+            using var connection = Storage.CreateAndOpenConnection();
             connection.Database.Insert(new HangfireJob()
             {
                 InvocationData = "",
@@ -95,7 +91,7 @@ namespace Hangfire.Storage.SQLite.Test
         [Fact]
         public void Execute_Processes_ListTable()
         {
-            using var connection = _storage.CreateAndOpenConnection();
+            using var connection = Storage.CreateAndOpenConnection();
             connection.Database.Insert(new HangfireList()
             {
                 Key = "key",
@@ -112,7 +108,7 @@ namespace Hangfire.Storage.SQLite.Test
         [Fact]
         public void Execute_Processes_SetTable()
         {
-            using var connection = _storage.CreateAndOpenConnection();
+            using var connection = Storage.CreateAndOpenConnection();
             connection.Database.Insert(new Set
             {
                 Key = "key",
@@ -131,7 +127,7 @@ namespace Hangfire.Storage.SQLite.Test
         [Fact]
         public void Execute_Processes_HashTable()
         {
-            using var connection = _storage.CreateAndOpenConnection();
+            using var connection = Storage.CreateAndOpenConnection();
             connection.Database.Insert(new Hash()
             {
                 Key = "key",
@@ -151,7 +147,7 @@ namespace Hangfire.Storage.SQLite.Test
         [Fact]
         public void Execute_Processes_AggregatedCounterTable()
         {
-            using var connection = _storage.CreateAndOpenConnection();
+            using var connection = Storage.CreateAndOpenConnection();
             connection.Database.Insert(new AggregatedCounter
             {
                 Key = "key",
@@ -199,7 +195,7 @@ namespace Hangfire.Storage.SQLite.Test
 
         private ExpirationManager CreateManager()
         {
-            return new ExpirationManager(_storage);
+            return new ExpirationManager(Storage);
         }
 
         private static void Commit(HangfireDbContext connection, Action<SQLiteWriteOnlyTransaction> action)

--- a/src/test/Hangfire.Storage.SQLite.Test/SQLiteConnectionFacts.GetFirstByLowestScoreFromSet.cs
+++ b/src/test/Hangfire.Storage.SQLite.Test/SQLiteConnectionFacts.GetFirstByLowestScoreFromSet.cs
@@ -1,14 +1,5 @@
-﻿using Hangfire.Common;
-using Hangfire.Server;
-using Hangfire.Storage.SQLite.Entities;
-using Hangfire.Storage.SQLite.Test.Utils;
-using Moq;
-using Newtonsoft.Json;
+﻿using Hangfire.Storage.SQLite.Entities;
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Threading;
 using Xunit;
 
 namespace Hangfire.Storage.SQLite.Test

--- a/src/test/Hangfire.Storage.SQLite.Test/SQLiteConnectionFacts.GetFirstByLowestScoreFromSet.cs
+++ b/src/test/Hangfire.Storage.SQLite.Test/SQLiteConnectionFacts.GetFirstByLowestScoreFromSet.cs
@@ -1,0 +1,165 @@
+﻿using Hangfire.Common;
+using Hangfire.Server;
+using Hangfire.Storage.SQLite.Entities;
+using Hangfire.Storage.SQLite.Test.Utils;
+using Moq;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using Xunit;
+
+namespace Hangfire.Storage.SQLite.Test
+{
+    public partial class HangfireSQLiteConnectionFacts
+    {
+        [Fact]
+        public void GetFirstByLowestScoreFromSet_ThrowsAnException_WhenKeyIsNull()
+        {
+            UseConnection((database, connection) =>
+            {
+                var exception = Assert.Throws<ArgumentNullException>(
+                    () => connection.GetFirstByLowestScoreFromSet(null, 0, 1));
+
+                Assert.Equal("key", exception.ParamName);
+            });
+        }
+
+        [Fact]
+        public void GetFirstByLowestScoreFromSet_ThrowsAnException_ToScoreIsLowerThanFromScore()
+        {
+            UseConnection((database, connection) => Assert.Throws<ArgumentException>(
+                () => connection.GetFirstByLowestScoreFromSet("key", 0, -1)));
+        }
+
+        [Fact]
+        public void GetFirstByLowestScoreFromSet_ReturnsNull_WhenTheKeyDoesNotExist()
+        {
+            UseConnection((database, connection) =>
+            {
+                var result = connection.GetFirstByLowestScoreFromSet(
+                    "key", 0, 1);
+
+                Assert.Null(result);
+            });
+        }
+
+        [Fact]
+        public void GetFirstByLowestScoreFromSet_ReturnsTheValueWithTheLowestScore()
+        {
+            UseConnection((database, connection) =>
+            {
+                database.Database.Insert(new Set
+                {
+                    Key = "key",
+                    Score = 1.0m,
+                    Value = "1.0"
+                });
+                database.Database.Insert(new Set
+                {
+                    Key = "key",
+                    Score = -1.0m,
+                    Value = "-1.0"
+                });
+                database.Database.Insert(new Set
+                {
+                    Key = "key",
+                    Score = -5.0m,
+                    Value = "-5.0"
+                });
+                database.Database.Insert(new Set
+                {
+                    Key = "another-key",
+                    Score = -2.0m,
+                    Value = "-2.0"
+                });
+
+                var result = connection.GetFirstByLowestScoreFromSet("key", -1.0, 3.0);
+
+                Assert.Equal("-1.0", result);
+            });
+        }
+        
+        [Fact]
+        [Trait("Feature", "BatchedGetFirstByLowestScoreFromSet")]
+        public void Batch_GetFirstByLowestScoreFromSet_ThrowsAnException_WhenKeyIsNull()
+        {
+            UseConnection((database, connection) =>
+            {
+                var exception = Assert.Throws<ArgumentNullException>(
+                    () => connection.GetFirstByLowestScoreFromSet(null, 0, 1, 1));
+
+                Assert.Equal("key", exception.ParamName);
+            });
+        }
+
+        [Fact]
+        [Trait("Feature", "BatchedGetFirstByLowestScoreFromSet")]
+        public void Batch_GetFirstByLowestScoreFromSet_ThrowsAnException_ToScoreIsLowerThanFromScore()
+        {
+            UseConnection((database, connection) => Assert.Throws<ArgumentException>(
+                () => connection.GetFirstByLowestScoreFromSet("key", 0, -1, 1)));
+        }
+
+        [Fact]
+        [Trait("Feature", "BatchedGetFirstByLowestScoreFromSet")]
+        public void Batch_GetFirstByLowestScoreFromSet_ReturnsNull_WhenTheKeyDoesNotExist()
+        {
+            UseConnection((database, connection) =>
+            {
+                var result = connection.GetFirstByLowestScoreFromSet(
+                    "key", 0, 1, 1);
+
+                Assert.Empty(result);
+            });
+        }
+        
+        [Fact]
+        [Trait("Feature", "BatchedGetFirstByLowestScoreFromSet")]
+        public void Batch_GetFirstByLowestScoreFromSet_ReturnsTheValuesWithTheLowestScore()
+        {
+            UseConnection((database, connection) =>
+            {
+                database.Database.InsertAll(new []
+                {
+                    new Set
+                    {
+                        Key = "key",
+                        Score = 1.0m,
+                        Value = "1.0"
+                    },
+                    new Set
+                    {
+                        Key = "key",
+                        Score = -1.0m,
+                        Value = "-1.0"
+                    },
+                    new Set
+                    {
+                        Key = "key",
+                        Score = -4.0m,
+                        Value = "-4.0"
+                    },
+                    new Set
+                    {
+                        Key = "key",
+                        Score = -5.0m,
+                        Value = "-5.0"
+                    },
+                    new Set
+                    {
+                        Key = "another-key",
+                        Score = -2.0m,
+                        Value = "-2.0"
+                    }
+                }, typeof(Set));
+
+                var result = connection.GetFirstByLowestScoreFromSet("key", -5.0, 3.0, count: 3);
+
+                Assert.Equal(new []{ "-5.0", "-4.0", "-1.0" }, result);
+            });
+        }
+    }
+}

--- a/src/test/Hangfire.Storage.SQLite.Test/SQLiteConnectionFacts.GetSetCount.cs
+++ b/src/test/Hangfire.Storage.SQLite.Test/SQLiteConnectionFacts.GetSetCount.cs
@@ -1,14 +1,5 @@
-﻿using Hangfire.Common;
-using Hangfire.Server;
-using Hangfire.Storage.SQLite.Entities;
-using Hangfire.Storage.SQLite.Test.Utils;
-using Moq;
-using Newtonsoft.Json;
+﻿using Hangfire.Storage.SQLite.Entities;
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.Linq;
-using System.Threading;
 using Xunit;
 
 namespace Hangfire.Storage.SQLite.Test

--- a/src/test/Hangfire.Storage.SQLite.Test/SQLiteConnectionFacts.GetSetCount.cs
+++ b/src/test/Hangfire.Storage.SQLite.Test/SQLiteConnectionFacts.GetSetCount.cs
@@ -1,0 +1,146 @@
+﻿using Hangfire.Common;
+using Hangfire.Server;
+using Hangfire.Storage.SQLite.Entities;
+using Hangfire.Storage.SQLite.Test.Utils;
+using Moq;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using Xunit;
+
+namespace Hangfire.Storage.SQLite.Test
+{
+    public partial class HangfireSQLiteConnectionFacts
+    {
+        [Fact]
+        [Trait("Feature", "ExtendedApi")]
+        public void GetSetCount_ThrowsAnException_WhenKeyIsNull()
+        {
+            UseConnection((database, connection) =>
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => connection.GetSetCount(null));
+            });
+        }
+
+        [Fact]
+        [Trait("Feature", "ExtendedApi")]
+        public void GetSetCount_ReturnsZero_WhenSetDoesNotExist()
+        {
+            UseConnection((database, connection) =>
+            {
+                var result = connection.GetSetCount("my-set");
+                Assert.Equal(0, result);
+            });
+        }
+
+        [Fact]
+        [Trait("Feature", "ExtendedApi")]
+        public void GetSetCount_ReturnsNumberOfElements_InASet()
+        {
+            UseConnection((database, connection) =>
+            {
+                database.Database.Insert(new Set
+                {
+                    Key = "set-1",
+                    Value = "value-1"
+                });
+                database.Database.Insert(new Set
+                {
+                    Key = "set-2",
+                    Value = "value-1"
+                });
+                database.Database.Insert(new Set
+                {
+                    Key = "set-1",
+                    Value = "value-2"
+                });
+
+                var result = connection.GetSetCount("set-1");
+
+                Assert.Equal(2, result);
+            });
+        }
+        
+        [Fact]
+        [Trait("Feature", "Connection.GetSetCount.Limited")]
+        public void Limited_GetSetCount_ThrowsAnException_WhenKeyIsNull()
+        {
+            UseConnection((database, connection) =>
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => connection.GetSetCount(null));
+            });
+        }
+
+        [Fact]
+        [Trait("Feature", "Connection.GetSetCount.Limited")]
+        public void Limited_GetSetCount_ReturnsZero_WhenSetDoesNotExist()
+        {
+            UseConnection((database, connection) =>
+            {
+                var result = connection.GetSetCount(new []{"my-set"}, 1);
+                Assert.Equal(0, result);
+            });
+        }
+
+        [Fact]
+        [Trait("Feature", "Connection.GetSetCount.Limited")]
+        public void Limited_GetSetCount_Returns_UpToLimit_NumberOfElements_InASet()
+        {
+            UseConnection((database, connection) =>
+            {
+                database.Database.Insert(new Set
+                {
+                    Key = "set-1",
+                    Value = "value-1"
+                });
+                database.Database.Insert(new Set
+                {
+                    Key = "set-2",
+                    Value = "value-1"
+                });
+                database.Database.Insert(new Set
+                {
+                    Key = "set-1",
+                    Value = "value-2"
+                });
+
+                var result = connection.GetSetCount(new []{"set-1", "set-2"}, 2);
+
+                Assert.Equal(2, result);
+            });
+        }
+        
+        [Fact]
+        [Trait("Feature", "Connection.GetSetCount.Limited")]
+        public void Limited_GetSetCount_Returns_AllCounts_IfLimitHighEnough()
+        {
+            UseConnection((database, connection) =>
+            {
+                database.Database.Insert(new Set
+                {
+                    Key = "set-1",
+                    Value = "value-1"
+                });
+                database.Database.Insert(new Set
+                {
+                    Key = "set-2",
+                    Value = "value-1"
+                });
+                database.Database.Insert(new Set
+                {
+                    Key = "set-1",
+                    Value = "value-2"
+                });
+
+                var result = connection.GetSetCount(new []{"set-1", "set-2"}, 99999);
+
+                Assert.Equal(3, result);
+            });
+        }
+    }
+}

--- a/src/test/Hangfire.Storage.SQLite.Test/SQLiteConnectionFacts.cs
+++ b/src/test/Hangfire.Storage.SQLite.Test/SQLiteConnectionFacts.cs
@@ -117,7 +117,7 @@ namespace Hangfire.Storage.SQLite.Test
             {
                 var exception = Assert.Throws<ArgumentNullException>(
                     () => connection.CreateExpiredJob(
-                        Job.FromExpression(() => SampleMethod("hello")),
+                        Job.FromExpression(() => TestJobClass.SampleMethod("hello")),
                         null,
                         DateTime.UtcNow,
                         TimeSpan.Zero));
@@ -133,7 +133,7 @@ namespace Hangfire.Storage.SQLite.Test
             {
                 var createdAt = new DateTime(2012, 12, 12, 0, 0, 0, 0, DateTimeKind.Utc);
                 var jobId = connection.CreateExpiredJob(
-                    Job.FromExpression(() => SampleMethod("Hello")),
+                    Job.FromExpression(() => TestJobClass.SampleMethod("Hello")),
                     new Dictionary<string, string> { { "Key1", "Value1" }, { "Key2", "Value2" } },
                     createdAt,
                     TimeSpan.FromDays(1));
@@ -152,7 +152,7 @@ namespace Hangfire.Storage.SQLite.Test
                 invocationData.Arguments = databaseJob.Arguments;
 
                 var job = invocationData.DeserializeJob();
-                Assert.Equal(typeof(HangfireSQLiteConnectionFacts), job.Type);
+                Assert.Equal(typeof(TestJobClass), job.Type);
                 Assert.Equal("SampleMethod", job.Method.Name);
                 Assert.Equal("Hello", job.Args[0]);
 
@@ -193,7 +193,7 @@ namespace Hangfire.Storage.SQLite.Test
         {
             UseConnection((database, connection) =>
             {
-                var job = Job.FromExpression(() => SampleMethod("wrong"));
+                var job = Job.FromExpression(() => TestJobClass.SampleMethod("wrong"));
 
                 var hangfireJob = new HangfireJob
                 {
@@ -1454,6 +1454,11 @@ namespace Hangfire.Storage.SQLite.Test
             action(database, connection);
         }
 
+        
+    }
+
+    public class TestJobClass
+    {
         public static void SampleMethod(string arg)
         {
             Debug.WriteLine(arg);

--- a/src/test/Hangfire.Storage.SQLite.Test/SQLiteConnectionFacts.cs
+++ b/src/test/Hangfire.Storage.SQLite.Test/SQLiteConnectionFacts.cs
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace Hangfire.Storage.SQLite.Test
 {
-    public class HangfireSQLiteConnectionFacts
+    public partial class HangfireSQLiteConnectionFacts
     {
         private readonly Mock<IPersistentJobQueue> _queue;
         private readonly PersistentJobQueueProviderCollection _providers;
@@ -472,73 +472,6 @@ namespace Hangfire.Storage.SQLite.Test
         }
 
         [Fact]
-        public void GetFirstByLowestScoreFromSet_ThrowsAnException_WhenKeyIsNull()
-        {
-            UseConnection((database, connection) =>
-            {
-                var exception = Assert.Throws<ArgumentNullException>(
-                    () => connection.GetFirstByLowestScoreFromSet(null, 0, 1));
-
-                Assert.Equal("key", exception.ParamName);
-            });
-        }
-
-        [Fact]
-        public void GetFirstByLowestScoreFromSet_ThrowsAnException_ToScoreIsLowerThanFromScore()
-        {
-            UseConnection((database, connection) => Assert.Throws<ArgumentException>(
-                () => connection.GetFirstByLowestScoreFromSet("key", 0, -1)));
-        }
-
-        [Fact]
-        public void GetFirstByLowestScoreFromSet_ReturnsNull_WhenTheKeyDoesNotExist()
-        {
-            UseConnection((database, connection) =>
-            {
-                var result = connection.GetFirstByLowestScoreFromSet(
-                    "key", 0, 1);
-
-                Assert.Null(result);
-            });
-        }
-
-        [Fact]
-        public void GetFirstByLowestScoreFromSet_ReturnsTheValueWithTheLowestScore()
-        {
-            UseConnection((database, connection) =>
-            {
-                database.Database.Insert(new Set
-                {
-                    Key = "key",
-                    Score = 1.0m,
-                    Value = "1.0"
-                });
-                database.Database.Insert(new Set
-                {
-                    Key = "key",
-                    Score = -1.0m,
-                    Value = "-1.0"
-                });
-                database.Database.Insert(new Set
-                {
-                    Key = "key",
-                    Score = -5.0m,
-                    Value = "-5.0"
-                });
-                database.Database.Insert(new Set
-                {
-                    Key = "another-key",
-                    Score = -2.0m,
-                    Value = "-2.0"
-                });
-
-                var result = connection.GetFirstByLowestScoreFromSet("key", -1.0, 3.0);
-
-                Assert.Equal("-1.0", result);
-            });
-        }
-
-        [Fact]
         public void AnnounceServer_ThrowsAnException_WhenServerIdIsNull()
         {
             UseConnection((database, connection) =>
@@ -771,6 +704,28 @@ namespace Hangfire.Storage.SQLite.Test
             });
         }
 
+        [Theory]
+        [InlineData("v1", true)]
+        [InlineData("v2", false)]
+        public void GetSetContains_Returns_True_If_Value_Found(string value, bool contains)
+        {
+            UseConnection((database, connection) =>
+            {
+                // Arrange
+                database.Database.Insert(new Set
+                {
+                    Key = "list-1",
+                    Value = "v1"
+                });
+
+                // Act
+                var result = connection.GetSetContains("list-1", value);
+
+                // Assert
+                Assert.Equal(contains, result);
+            });
+        }
+
         [Fact]
         public void SetRangeInHash_ThrowsAnException_WhenKeyIsNull()
         {
@@ -864,53 +819,6 @@ namespace Hangfire.Storage.SQLite.Test
                 Assert.Equal(2, result.Count);
                 Assert.Equal("Value1", result["Key1"]);
                 Assert.Equal("Value2", result["Key2"]);
-            });
-        }
-
-        [Fact]
-        public void GetSetCount_ThrowsAnException_WhenKeyIsNull()
-        {
-            UseConnection((database, connection) =>
-            {
-                Assert.Throws<ArgumentNullException>(
-                    () => connection.GetSetCount(null));
-            });
-        }
-
-        [Fact]
-        public void GetSetCount_ReturnsZero_WhenSetDoesNotExist()
-        {
-            UseConnection((database, connection) =>
-            {
-                var result = connection.GetSetCount("my-set");
-                Assert.Equal(0, result);
-            });
-        }
-
-        [Fact]
-        public void GetSetCount_ReturnsNumberOfElements_InASet()
-        {
-            UseConnection((database, connection) =>
-            {
-                database.Database.Insert(new Set
-                {
-                    Key = "set-1",
-                    Value = "value-1"
-                });
-                database.Database.Insert(new Set
-                {
-                    Key = "set-2",
-                    Value = "value-1"
-                });
-                database.Database.Insert(new Set
-                {
-                    Key = "set-1",
-                    Value = "value-2"
-                });
-
-                var result = connection.GetSetCount("set-1");
-
-                Assert.Equal(2, result);
             });
         }
 
@@ -1523,6 +1431,22 @@ namespace Hangfire.Storage.SQLite.Test
                 Assert.Equal(new[] { "5", "4", "3", "1" }, result);
             });
         }
+
+        [Fact]
+        public void GetUtcDateTime_IsSupported()
+        {
+            UseConnection((_, conn) =>
+            {
+                var start = DateTime.UtcNow;
+
+                // Act
+                var utcDateTime = conn.GetUtcDateTime();
+                var end = DateTime.UtcNow;
+
+                Assert.InRange(utcDateTime, start, end);
+            });
+        }
+
         private void UseConnection(Action<HangfireDbContext, HangfireSQLiteConnection> action)
         {
             using var database = ConnectionUtils.CreateConnection();

--- a/src/test/Hangfire.Storage.SQLite.Test/SQLiteConnectionFacts.cs
+++ b/src/test/Hangfire.Storage.SQLite.Test/SQLiteConnectionFacts.cs
@@ -13,7 +13,7 @@ using Xunit;
 
 namespace Hangfire.Storage.SQLite.Test
 {
-    public partial class HangfireSQLiteConnectionFacts
+    public partial class HangfireSQLiteConnectionFacts : SqliteInMemoryTestBase
     {
         private readonly Mock<IPersistentJobQueue> _queue;
         private readonly PersistentJobQueueProviderCollection _providers;
@@ -41,7 +41,7 @@ namespace Hangfire.Storage.SQLite.Test
         public void Ctor_ThrowsAnException_WhenProvidersCollectionIsNull()
         {
             var exception = Assert.Throws<ArgumentNullException>(
-                () => new HangfireSQLiteConnection(ConnectionUtils.CreateConnection(), null));
+                () => new HangfireSQLiteConnection(Storage.CreateAndOpenConnection(), null));
 
             Assert.Equal("queueProviders", exception.ParamName);
         }
@@ -1449,7 +1449,7 @@ namespace Hangfire.Storage.SQLite.Test
 
         private void UseConnection(Action<HangfireDbContext, HangfireSQLiteConnection> action)
         {
-            using var database = ConnectionUtils.CreateConnection();
+            using var database = Storage.CreateAndOpenConnection();
             using var connection = new HangfireSQLiteConnection(database, _providers);
             action(database, connection);
         }

--- a/src/test/Hangfire.Storage.SQLite.Test/SQLiteDistributedLockFacts.cs
+++ b/src/test/Hangfire.Storage.SQLite.Test/SQLiteDistributedLockFacts.cs
@@ -9,7 +9,7 @@ using Xunit;
 
 namespace Hangfire.Storage.SQLite.Test
 {
-    public class SQLiteDistributedLockFacts
+    public class SQLiteDistributedLockFacts : SqliteInMemoryTestBase
     {
         [Fact]
         public void Ctor_ThrowsAnException_WhenResourceIsNull()
@@ -117,7 +117,6 @@ namespace Hangfire.Storage.SQLite.Test
         [Fact]
         public void Ctor_WaitForLock_SignaledAtLockRelease()
         {
-            var storage = ConnectionUtils.CreateStorage();
             using var mre = new ManualResetEventSlim();
             var t = NewBackgroundThread(() =>
             {
@@ -128,7 +127,7 @@ namespace Hangfire.Storage.SQLite.Test
                         mre.Set();
                         Thread.Sleep(TimeSpan.FromSeconds(3));
                     }
-                }, storage);
+                });
             });
             UseConnection(database =>
             {
@@ -145,7 +144,7 @@ namespace Hangfire.Storage.SQLite.Test
                 }
 
                 t.Join();
-            }, storage);
+            });
         }
 
         [Fact]
@@ -306,15 +305,15 @@ namespace Hangfire.Storage.SQLite.Test
             }
         }
         
-        private static void UseConnection(Action<HangfireDbContext> action, SQLiteStorage storage = null)
+        private void UseConnection(Action<HangfireDbContext> action)
         {
-            using var connection = storage?.CreateAndOpenConnection() ?? ConnectionUtils.CreateConnection();
+            using var connection = Storage.CreateAndOpenConnection();
             action(connection);
         }
         
-        private static async Task UseConnectionAsync(Func<HangfireDbContext, Task> func, SQLiteStorage storage = null)
+        private async Task UseConnectionAsync(Func<HangfireDbContext, Task> func)
         {
-            using var connection = storage?.CreateAndOpenConnection() ?? ConnectionUtils.CreateConnection();
+            using var connection = Storage.CreateAndOpenConnection();
             await func(connection);
         }
     }

--- a/src/test/Hangfire.Storage.SQLite.Test/SQLiteFetchedJobFacts.cs
+++ b/src/test/Hangfire.Storage.SQLite.Test/SQLiteFetchedJobFacts.cs
@@ -1,12 +1,11 @@
 using Hangfire.Storage.SQLite.Entities;
-using Hangfire.Storage.SQLite.Test.Utils;
 using System;
 using System.Linq;
 using Xunit;
 
 namespace Hangfire.Storage.SQLite.Test
 {
-    public class SQLiteFetchedJobFacts
+    public class SQLiteFetchedJobFacts : SqliteInMemoryTestBase
     {
         private const int JobId = 0;
         private const string Queue = "queue";
@@ -153,9 +152,9 @@ namespace Hangfire.Storage.SQLite.Test
             return jobQueue.Id;
         }
 
-        private static void UseConnection(Action<HangfireDbContext> action)
+        private void UseConnection(Action<HangfireDbContext> action)
         {
-            using var connection = ConnectionUtils.CreateConnection();
+            using var connection = Storage.CreateAndOpenConnection();
             action(connection);
         }
     }

--- a/src/test/Hangfire.Storage.SQLite.Test/SQLiteJobQueueFacts.cs
+++ b/src/test/Hangfire.Storage.SQLite.Test/SQLiteJobQueueFacts.cs
@@ -1,5 +1,4 @@
 using Hangfire.Storage.SQLite.Entities;
-using Hangfire.Storage.SQLite.Test.Utils;
 using System;
 using System.Linq;
 using System.Threading;
@@ -7,7 +6,7 @@ using Xunit;
 
 namespace Hangfire.Storage.SQLite.Test
 {
-    public class SQLiteJobQueueFacts
+    public class SQLiteJobQueueFacts : SqliteInMemoryTestBase
     {
         private static readonly string[] DefaultQueues = { "default" };
 
@@ -331,9 +330,9 @@ namespace Hangfire.Storage.SQLite.Test
             return new SQLiteJobQueue(connection, new SQLiteStorageOptions());
         }
 
-        private static void UseConnection(Action<HangfireDbContext> action)
+        private void UseConnection(Action<HangfireDbContext> action)
         {
-            using var connection = ConnectionUtils.CreateConnection();
+            using var connection = Storage.CreateAndOpenConnection();
             action(connection);
         }
     }

--- a/src/test/Hangfire.Storage.SQLite.Test/SQLiteMonitoringApiFacts.cs
+++ b/src/test/Hangfire.Storage.SQLite.Test/SQLiteMonitoringApiFacts.cs
@@ -1,7 +1,6 @@
 ﻿using Hangfire.Common;
 using Hangfire.States;
 using Hangfire.Storage.SQLite.Entities;
-using Hangfire.Storage.SQLite.Test.Utils;
 using Moq;
 using Newtonsoft.Json;
 using System;
@@ -10,7 +9,7 @@ using Xunit;
 
 namespace Hangfire.Storage.SQLite.Test
 {
-    public class SQLiteMonitoringApiFacts
+    public class SQLiteMonitoringApiFacts : SqliteInMemoryTestBase
     {
         private const string DefaultQueue = "default";
         private const string FetchedStateName = "Fetched";
@@ -282,9 +281,8 @@ namespace Hangfire.Storage.SQLite.Test
 
         private void UseMonitoringApi(Action<HangfireDbContext, SQLiteMonitoringApi> action)
         {
-            using var storage = ConnectionUtils.CreateStorage();
-            var connection = new SQLiteMonitoringApi(storage, _providers);
-            using var dbContext = storage.CreateAndOpenConnection();
+            var connection = new SQLiteMonitoringApi(Storage, _providers);
+            using var dbContext = Storage.CreateAndOpenConnection();
             action(dbContext, connection);
         }
 

--- a/src/test/Hangfire.Storage.SQLite.Test/SQLiteWriteOnlyTransactionFacts.cs
+++ b/src/test/Hangfire.Storage.SQLite.Test/SQLiteWriteOnlyTransactionFacts.cs
@@ -10,7 +10,7 @@ using Xunit;
 
 namespace Hangfire.Storage.SQLite.Test
 {
-    public class SQLiteWriteOnlyTransactionFacts
+    public class SQLiteWriteOnlyTransactionFacts : SqliteInMemoryTestBase
     {
         private readonly PersistentJobQueueProviderCollection _queueProviders;
 
@@ -34,7 +34,7 @@ namespace Hangfire.Storage.SQLite.Test
         [Fact]
         public void Ctor_ThrowsAnException_IfProvidersCollectionIsNull()
         {
-            var exception = Assert.Throws<ArgumentNullException>(() => new SQLiteWriteOnlyTransaction(ConnectionUtils.CreateConnection(), null));
+            var exception = Assert.Throws<ArgumentNullException>(() => new SQLiteWriteOnlyTransaction(Storage.CreateAndOpenConnection(), null));
 
             Assert.Equal("queueProviders", exception.ParamName);
         }
@@ -956,7 +956,7 @@ namespace Hangfire.Storage.SQLite.Test
 
         private void UseConnection(Action<HangfireDbContext> action)
         {
-            using var connection = ConnectionUtils.CreateConnection();
+            using var connection = Storage.CreateAndOpenConnection();
             action(connection);
         }
 

--- a/src/test/Hangfire.Storage.SQLite.Test/SqliteInMemoryTestBase.cs
+++ b/src/test/Hangfire.Storage.SQLite.Test/SqliteInMemoryTestBase.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Hangfire.Storage.SQLite.Test.Utils;
+
+namespace Hangfire.Storage.SQLite.Test;
+
+public class SqliteInMemoryTestBase : IDisposable
+{
+    protected SQLiteStorage Storage { get; } = ConnectionUtils.CreateStorage();
+    /// <summary>
+    /// This connection ensures that an in-memory database
+    /// will stay alive until the test finishes
+    /// </summary>
+    private readonly IDisposable _rootingInMemoryConnection;
+
+    protected SqliteInMemoryTestBase()
+    {
+        _rootingInMemoryConnection = Storage.CreateAndOpenConnection();
+    }
+
+    public virtual void Dispose()
+    {
+        _rootingInMemoryConnection?.Dispose();
+        Storage?.Dispose();
+    }
+}


### PR DESCRIPTION
This PR implements the following features

- `SQLiteWriteOnlyTransaction.AcquireDistributedLock` (`Transaction.AcquireDistributedLock`)
- `HangfireSQLiteConnection.GetSetCount`-Limited (`Connection.GetSetCount.Limited`)
- `HangfireSQLiteConnection.GetSetContains` (`Connection.GetSetContains`)
- `HangfireSQLiteConnection.GetFirstByLowestScoreFromSet` (`Connection.BatchedGetFirstByLowestScoreFromSet`)
- `HangfireSQLiteConnection.GetUtcDateTime` (`Connection.GetUtcDateTime`)

and ignores an ObjectDisposedException when the Heartbeat timer already got disposed while being fired

Feature diff is

```
{ "Storage.ExtendedApi", false },                            -> true
{ "Job.Queue", true },
{ "Connection.GetUtcDateTime", false },                      -> true
{ "Connection.BatchedGetFirstByLowestScoreFromSet", false }, -> true
{ "Connection.GetSetContains", true },                       -> true, was not implemented before, but marked as true
{ "Connection.GetSetCount.Limited", false },                 -> true
{ "BatchedGetFirstByLowestScoreFromSet", false },            -> true
{ "Transaction.AcquireDistributedLock", true },              -> true, was not implemented before, but marked as true
{ "Transaction.CreateJob", true },                           -> false, is not implemented, we should not advertise it
{ "Transaction.SetJobParameter", true },                     -> false, is not implemented, we should not advertise it
{ "TransactionalAcknowledge:InMemoryFetchedJob", false },
{ "Monitoring.DeletedStateGraphs", false },
{ "Monitoring.AwaitingJobs", false }
```

Addtionally:
- introduced `SqliteInMemoryTestBase` to simplify correct usage of in-memory database
  - as in-memory databases get deleted once their last connection is "closed", we should always ensure that a test keeps the database alive until its finished, no matter how often the newly created connections get closed.
- improve performance when acquiring connections, by only migrating the tables on the creation of the storage
- reduced allocations by making use of `TState`-parameter introduced in `TryFewTimesDueToConcurrency`
- replace manual `SQLITE_OPEN_URI`-constant with `SQLitePCL.raw.SQLITE_OPEN_URI`
