### PR TITLE
Upgrade project to .NET 8, latest Hangfire.Core reference and fix RID graph warnings

### DIFF
--- a/src/main/Hangfire.Storage.SQLite/CountersAggregator.cs
+++ b/src/main/Hangfire.Storage.SQLite/CountersAggregator.cs
@@ -1,10 +1,10 @@
 ﻿using Hangfire.Annotations;
 using Hangfire.Logging;
 using Hangfire.Server;
+using Hangfire.Storage.SQLite.Entities;
 using System;
 using System.Linq;
 using System.Threading;
-using Hangfire.Storage.SQLite.Entities;
 
 namespace Hangfire.Storage.SQLite
 {

--- a/src/main/Hangfire.Storage.SQLite/Hangfire.Storage.SQLite.csproj
+++ b/src/main/Hangfire.Storage.SQLite/Hangfire.Storage.SQLite.csproj
@@ -1,42 +1,43 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
-    <TargetFramework>netstandard2.0</TargetFramework>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
-    <TargetFrameworks>netstandard2.0;net48</TargetFrameworks>
-  </PropertyGroup>
-  <PropertyGroup>
-    <Version>0.4.2</Version>
-    <Authors>RaisedApp</Authors>
-    <Company>RaisedApp</Company>
-    <Copyright>Copyright © 2019 - Present</Copyright>
-    <PackageLicenseFile>LICENSE</PackageLicenseFile>
-    <PackageProjectUrl>https://github.com/raisedapp/Hangfire.Storage.SQLite</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/raisedapp/Hangfire.Storage.SQLite</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PackageTags>Hangfire Hangfire-Storage Hangfire-Extension SQLite</PackageTags>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <title>Hangfire Storage SQLite</title>    
-    <Description>An Alternative SQLite Storage for Hangfire</Description>
-    <PackageReleaseNotes>
-      0.4.2
-      -remove re-entrancy (fixes SQLiteDistributedLock doesn't play right with async #68). Thanks to @kirides
-      -pause heartbeat timer while processing. Thanks to @kirides
-      -update expiration using SQL Update statement in a single step. Thanks to @kirides
-      -Added Heartbeat event (for testing). Thanks to @kirides
-      -if we no longer own the lock, we immediately dispose the heartbeat timer (fixes Unable to update heartbeat - still happening in .NET 6.0 #69). Thanks to @kirides
-    </PackageReleaseNotes>
-  </PropertyGroup>
-  <ItemGroup>
-    <None Include="..\..\..\LICENSE">
-      <Pack>True</Pack>
-      <PackagePath></PackagePath>
-    </None>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="Hangfire.Core" Version="1.8.0" />
-    <PackageReference Include="sqlite-net-pcl" Version="1.8.116" />
-  </ItemGroup>
+	<PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
+		<TargetFramework>netstandard2.0</TargetFramework>
+	</PropertyGroup>
+	<PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
+		<TargetFrameworks>netstandard2.0;net48</TargetFrameworks>
+	</PropertyGroup>
+	<PropertyGroup>
+		<Version>0.4.3</Version>
+		<Authors>RaisedApp</Authors>
+		<Company>RaisedApp</Company>
+		<Copyright>Copyright © 2019 - Present</Copyright>
+		<PackageLicenseFile>LICENSE</PackageLicenseFile>
+		<PackageProjectUrl>https://github.com/raisedapp/Hangfire.Storage.SQLite</PackageProjectUrl>
+		<RepositoryUrl>https://github.com/raisedapp/Hangfire.Storage.SQLite</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
+		<PackageTags>Hangfire Hangfire-Storage Hangfire-Extension SQLite</PackageTags>
+		<GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+		<title>Hangfire Storage SQLite</title>
+		<Description>An Alternative SQLite Storage for Hangfire</Description>
+		<PackageReleaseNotes>
+			0.4.3
+			- Upgrade projects to .NET 8.0 (LTS).
+			- Update dependencies (Hangfire 1.8.23, Newtonsoft.Json 13.0.4).
+			- Explicitly referenced SQLitePCLRaw.bundle_green 2.1.11 to resolve NETSDK1206 RID-related warnings.
+			- Support for modern Hangfire 1.8 background process registration (GetStorageWideProcesses).
+		</PackageReleaseNotes>
+	</PropertyGroup>
+	<ItemGroup>
+		<None Include="..\..\..\LICENSE">
+			<Pack>True</Pack>
+			<PackagePath></PackagePath>
+		</None>
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Hangfire.Core" Version="1.8.23" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+		<PackageReference Include="sqlite-net-pcl" Version="1.9.172" />
+		<PackageReference Include="SQLitePCLRaw.bundle_green" Version="2.1.11" />
+	</ItemGroup>
 
 </Project>

--- a/src/main/Hangfire.Storage.SQLite/HangfireDbContext.cs
+++ b/src/main/Hangfire.Storage.SQLite/HangfireDbContext.cs
@@ -1,6 +1,5 @@
 ﻿using Hangfire.Logging;
 using Hangfire.Storage.SQLite.Entities;
-using Newtonsoft.Json;
 using SQLite;
 using System;
 using System.Threading;
@@ -42,7 +41,7 @@ namespace Hangfire.Storage.SQLite
 
             ConnectionId = Guid.NewGuid().ToString();
         }
-        
+
         /// <summary>
         /// Initializes initial tables schema for Hangfire
         /// </summary>
@@ -62,7 +61,7 @@ namespace Hangfire.Storage.SQLite
             TryFewTimesDueToConcurrency(() => Database.CreateTable<Set>());
             TryFewTimesDueToConcurrency(() => Database.CreateTable<State>());
             TryFewTimesDueToConcurrency(() => Database.CreateTable<DistributedLock>());
-            
+
             void TryFewTimesDueToConcurrency(Action action, int times = 10)
             {
                 var current = 0;
@@ -136,7 +135,7 @@ namespace Hangfire.Storage.SQLite
                 Database = null;
             }
         }
-        
+
         public void Dispose()
         {
             Dispose(true);

--- a/src/main/Hangfire.Storage.SQLite/PooledHangfireDbContext.cs
+++ b/src/main/Hangfire.Storage.SQLite/PooledHangfireDbContext.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using SQLite;
+﻿using SQLite;
+using System;
 
 namespace Hangfire.Storage.SQLite
 {
@@ -8,7 +8,7 @@ namespace Hangfire.Storage.SQLite
         private readonly Action<PooledHangfireDbContext> _onDispose;
         public bool PhaseOut { get; set; }
 
-        internal PooledHangfireDbContext(SQLiteConnection connection, Action<PooledHangfireDbContext> onDispose, string prefix = "hangfire") 
+        internal PooledHangfireDbContext(SQLiteConnection connection, Action<PooledHangfireDbContext> onDispose, string prefix = "hangfire")
             : base(connection, prefix)
         {
             _onDispose = onDispose ?? throw new ArgumentNullException(nameof(onDispose));

--- a/src/main/Hangfire.Storage.SQLite/SQLiteDbConnectionFactory.cs
+++ b/src/main/Hangfire.Storage.SQLite/SQLiteDbConnectionFactory.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using SQLite;
+﻿using SQLite;
+using System;
 
 namespace Hangfire.Storage.SQLite
 {

--- a/src/main/Hangfire.Storage.SQLite/SQLiteDistributedLock.cs
+++ b/src/main/Hangfire.Storage.SQLite/SQLiteDistributedLock.cs
@@ -28,7 +28,7 @@ namespace Hangfire.Storage.SQLite
         private string EventWaitHandleName => string.Intern($@"{GetType().FullName}.{_resource}");
 
         public event Action<bool> Heartbeat;
-        
+
         /// <summary>
         /// Creates SQLite distributed lock
         /// </summary>
@@ -117,7 +117,7 @@ namespace Hangfire.Storage.SQLite
                     return;
                 }
 
-                var waitTime = (int) timeout.TotalMilliseconds / 10;
+                var waitTime = (int)timeout.TotalMilliseconds / 10;
                 // either wait for the event to be raised, or timeout
                 lock (EventWaitHandleName)
                 {
@@ -134,7 +134,8 @@ namespace Hangfire.Storage.SQLite
         /// <exception cref="DistributedLockTimeoutException"></exception>
         private void Release()
         {
-            Retry.Twice((retry) => {
+            Retry.Twice((retry) =>
+            {
 
                 // Remove resource lock (if it's still ours)
                 var count = _dbContext.DistributedLockRepository.Delete(_ => _.Resource == _resource && _.ResourceKey == _resourceKey);
@@ -150,7 +151,8 @@ namespace Hangfire.Storage.SQLite
         {
             try
             {
-                Retry.Twice((_) => {
+                Retry.Twice((_) =>
+                {
                     // Delete expired locks (of any owner)
                     _dbContext.DistributedLockRepository.
                         Delete(x => x.Resource == _resource && x.ExpireAt < DateTime.UtcNow);

--- a/src/main/Hangfire.Storage.SQLite/SQLiteMonitoringApi.cs
+++ b/src/main/Hangfire.Storage.SQLite/SQLiteMonitoringApi.cs
@@ -1,12 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using Hangfire.Common;
+﻿using Hangfire.Common;
 using Hangfire.States;
 using Hangfire.Storage.Monitoring;
 using Hangfire.Storage.SQLite.Entities;
 using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Hangfire.Storage.SQLite
 {

--- a/src/main/Hangfire.Storage.SQLite/SQLiteStorage.cs
+++ b/src/main/Hangfire.Storage.SQLite/SQLiteStorage.cs
@@ -58,7 +58,8 @@ namespace Hangfire.Storage.SQLite
                 string.IsNullOrWhiteSpace(databasePath) ? throw new ArgumentNullException(nameof(databasePath)) : databasePath,
                 SQLiteOpenFlags.ReadWrite | SQLiteOpenFlags.Create | SQLiteOpenFlags.NoMutex,
                 storeDateTimeAsTicks: true
-            ) {BusyTimeout = TimeSpan.FromSeconds(10)}), storageOptions)
+            )
+            { BusyTimeout = TimeSpan.FromSeconds(10) }), storageOptions)
         {
         }
 
@@ -135,6 +136,8 @@ namespace Hangfire.Storage.SQLite
         {
             if (featureId == null) throw new ArgumentNullException(nameof(featureId));
 
+            if (featureId == "JobStorage.ProcessesInsteadOfComponents") return true;
+
             return _features.TryGetValue(featureId, out var isSupported)
                 ? isSupported
                 : base.HasFeature(featureId);
@@ -187,9 +190,18 @@ namespace Hangfire.Storage.SQLite
         /// 
         /// </summary>
         /// <returns></returns>
-#pragma warning disable 618
+        public override IEnumerable<IBackgroundProcess> GetStorageWideProcesses()
+        {
+            yield return new ExpirationManager(this, _storageOptions.JobExpirationCheckInterval);
+            yield return new CountersAggregator(this, _storageOptions.CountersAggregateInterval);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <returns></returns>
+        [Obsolete("Please use GetStorageWideProcesses instead. Will be removed with Hangfire.Core 2.0.0.")]
         public override IEnumerable<IServerComponent> GetComponents()
-#pragma warning restore 618
         {
             yield return new ExpirationManager(this, _storageOptions.JobExpirationCheckInterval);
             yield return new CountersAggregator(this, _storageOptions.CountersAggregateInterval);

--- a/src/main/Hangfire.Storage.SQLite/SQLiteStorageExtensions.cs
+++ b/src/main/Hangfire.Storage.SQLite/SQLiteStorageExtensions.cs
@@ -1,7 +1,5 @@
 ﻿using Hangfire.Annotations;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Hangfire.Storage.SQLite
 {
@@ -20,9 +18,9 @@ namespace Hangfire.Storage.SQLite
             [NotNull] this IGlobalConfiguration configuration)
         {
             if (configuration == null) throw new ArgumentNullException(nameof(configuration));
-            
+
             var storage = new SQLiteStorage("Hangfire.db", new SQLiteStorageOptions());
-            
+
             return configuration.UseStorage(storage);
         }
 
@@ -42,9 +40,9 @@ namespace Hangfire.Storage.SQLite
             if (configuration == null) throw new ArgumentNullException(nameof(configuration));
             if (nameOrConnectionString == null) throw new ArgumentNullException(nameof(nameOrConnectionString));
             if (options == null) options = new SQLiteStorageOptions();
-            
+
             var storage = new SQLiteStorage(nameOrConnectionString, options);
-            
+
             return configuration.UseStorage(storage);
         }
 

--- a/src/main/Hangfire.Storage.SQLite/SQLiteWriteOnlyTransaction.cs
+++ b/src/main/Hangfire.Storage.SQLite/SQLiteWriteOnlyTransaction.cs
@@ -1,11 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Linq.Expressions;
-using System.Text;
-using Hangfire.States;
+﻿using Hangfire.States;
 using Hangfire.Storage.SQLite.Entities;
 using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Hangfire.Storage.SQLite
 {
@@ -113,7 +111,8 @@ namespace Hangfire.Storage.SQLite
 
         public override void Commit()
         {
-            Retry.Twice((attempts) => {
+            Retry.Twice((attempts) =>
+            {
 
                 lock (_lockObject)
                 {

--- a/src/samples/ConsoleSample/ConsoleSample.csproj
+++ b/src/samples/ConsoleSample/ConsoleSample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/src/samples/WebSample/WebSample.csproj
+++ b/src/samples/WebSample/WebSample.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hangfire" Version="1.8.7" />
+    <PackageReference Include="Hangfire" Version="1.8.23" />
     <PackageReference Include="Hangfire.Heartbeat" Version="0.6.0" />
     <PackageReference Include="Hangfire.JobsLogger" Version="0.2.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/test/Hangfire.Storage.SQLite.Test/Hangfire.Storage.SQLite.Test.csproj
+++ b/src/test/Hangfire.Storage.SQLite.Test/Hangfire.Storage.SQLite.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <Authors>RaisedApp</Authors>
     <Company>RaisedApp</Company>
@@ -13,12 +13,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.0.1" />
-    <PackageReference Include="Xunit.SkippableFact" Version="1.3.12" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/test/Hangfire.Storage.SQLite.Test/SQLiteDistributedLockFacts.cs
+++ b/src/test/Hangfire.Storage.SQLite.Test/SQLiteDistributedLockFacts.cs
@@ -84,7 +84,7 @@ namespace Hangfire.Storage.SQLite.Test
                 }
             });
         }
-        
+
         private Thread NewBackgroundThread(ThreadStart start)
         {
             return new Thread(start)
@@ -156,7 +156,7 @@ namespace Hangfire.Storage.SQLite.Test
             using var manualResetEvent = new ManualResetEventSlim();
             var success = new bool[numThreads];
             var storage = ConnectionUtils.CreateStorage();
-            
+
             // Spawn multiple threads to race each other.
             var threads = Enumerable.Range(0, numThreads).Select(i => NewBackgroundThread(() =>
             {
@@ -244,7 +244,7 @@ namespace Hangfire.Storage.SQLite.Test
                 }
             });
         }
-        
+
         [Fact]
         public async Task Heartbeat_Fires_WithSuccess()
         {
@@ -260,7 +260,7 @@ namespace Hangfire.Storage.SQLite.Test
                 Assert.True(result);
             });
         }
-        
+
         [Fact]
         public void Heartbeat_Fires_With_Fail_If_Lock_No_Longer_Exists()
         {
@@ -305,13 +305,13 @@ namespace Hangfire.Storage.SQLite.Test
                 slock.Heartbeat -= onHeartbeat;
             }
         }
-        
+
         private static void UseConnection(Action<HangfireDbContext> action, SQLiteStorage storage = null)
         {
             using var connection = storage?.CreateAndOpenConnection() ?? ConnectionUtils.CreateConnection();
             action(connection);
         }
-        
+
         private static async Task UseConnectionAsync(Func<HangfireDbContext, Task> func, SQLiteStorage storage = null)
         {
             using var connection = storage?.CreateAndOpenConnection() ?? ConnectionUtils.CreateConnection();

--- a/src/test/Hangfire.Storage.SQLite.Test/SQLiteWriteOnlyTransactionFacts.cs
+++ b/src/test/Hangfire.Storage.SQLite.Test/SQLiteWriteOnlyTransactionFacts.cs
@@ -860,7 +860,7 @@ namespace Hangfire.Storage.SQLite.Test
 
                 var testSet2 = GetTestSet(database, set2.Key);
                 Assert.NotNull(testSet2);
-                Assert.Equal(1, testSet2.Count);
+                Assert.Single(testSet2);
             });
         }
 
@@ -882,10 +882,10 @@ namespace Hangfire.Storage.SQLite.Test
                 Commit(database, x => x.RemoveSet(set1Val1.Key));
 
                 var testSet1 = GetTestSet(database, set1Val1.Key);
-                Assert.Equal(0, testSet1.Count);
+                Assert.Empty(testSet1);
 
                 var testSet2 = GetTestSet(database, set2.Key);
-                Assert.Equal(1, testSet2.Count);
+                Assert.Single(testSet2);
             });
         }
 

--- a/src/test/Hangfire.Storage.SQLite.Test/Utils/ConnectionUtils.cs
+++ b/src/test/Hangfire.Storage.SQLite.Test/Utils/ConnectionUtils.cs
@@ -1,5 +1,5 @@
-using System;
 using SQLite;
+using System;
 
 namespace Hangfire.Storage.SQLite.Test.Utils
 {
@@ -16,12 +16,12 @@ namespace Hangfire.Storage.SQLite.Test.Utils
         {
             // See SQLite Docs: https://www.sqlite.org/c3ref/c_open_autoproxy.html
             // const SQLiteOpenFlags SQLITE_OPEN_MEMORY = (SQLiteOpenFlags) 0x00000080;
-            const SQLiteOpenFlags SQLITE_OPEN_URI = (SQLiteOpenFlags) 0x00000040;
+            const SQLiteOpenFlags SQLITE_OPEN_URI = (SQLiteOpenFlags)0x00000040;
             const SQLiteOpenFlags flags = // open the database in memory
-                // SQLITE_OPEN_MEMORY |
-                // SQLiteOpenFlags.SharedCache |
-                // for whatever reason, if we don't use URI-mode,
-                // shared in-memory databases dont work properly.
+                                          // SQLITE_OPEN_MEMORY |
+                                          // SQLiteOpenFlags.SharedCache |
+                                          // for whatever reason, if we don't use URI-mode,
+                                          // shared in-memory databases dont work properly.
                 SQLITE_OPEN_URI |
                 // open the database in read/write mode
                 SQLiteOpenFlags.ReadWrite |


### PR DESCRIPTION
This PR brings the project up to date with current standards. The main goal was to reference latest available hangfire.core, get off the out-of-support .NET 6 and fix the noisy warnings introduced by .NET 8's new RID graph.

  Core Changes:

   * Target Frameworks: Bumped the samples and tests to .NET 8. Since .NET 6 is EOL, this keeps the project on a
     supported LTS version.
   * Dependency Bumps: Updated Hangfire.Core to 1.8.23 and Newtonsoft.Json to 13.0.4. (current versions had vulnerabilities) Also refreshed the test stack
     (xUnit, Moq) to their latest stable versions. 
   * The RID Warning Fix (NETSDK1206): Instead of just suppressing the annoying .NET 8 warnings about alpine-x64 and
     other specific RIDs, I've explicitly added `SQLitePCLRaw.bundle_green` v2.1.11. This version handles the new .NET 8
     RID graph properly, so the build is now 100% warning-free without hacks.
   * Hangfire 1.8 API Alignment:
       * JobStorage.GetComponents() is being phased out (removed in 2.0), so I’ve implemented GetStorageWideProcesses()
         to register our ExpirationManager and CountersAggregator as IBackgroundProcess.
       * Updated HasFeature to signal support for JobStorage.ProcessesInsteadOfComponents.
       * Kept GetComponents with an [Obsolete] tag for backward compatibility so we don't break older setups.
   * Test & Build Cleanup:
       * Fixed a few xUnit analyzer warnings (swapped Assert.Equal(0, ...) for Assert.Empty(), etc.).
       * Decorated obsolete overrides in SQLiteStorage.cs to keep the compiler happy.