### PR TITLE
v0.4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,5 @@ Below is a description of them:
 
 This project is mainly based on **Hangfire.LiteDB** storage by [@codeyu](https://github.com/codeyu) (https://github.com/codeyu/Hangfire.LiteDB)
 
-## Donation
-If this project help you reduce time to develop, you can give me a cup of coffee :) 
-
-[![paypal](https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=RMLQM296TCM38&item_name=For+the+development+of+Hangfire.Storage.SQLite&currency_code=USD&source=url)
-
 ## License
 This project is under MIT license. You can obtain the license copy [here](https://github.com/raisedapp/Hangfire.Storage.SQLite/blob/develop/LICENSE).

--- a/src/main/Hangfire.Storage.SQLite/Hangfire.Storage.SQLite.csproj
+++ b/src/main/Hangfire.Storage.SQLite/Hangfire.Storage.SQLite.csproj
@@ -20,12 +20,12 @@
 		<title>Hangfire Storage SQLite</title>
 		<Description>An Alternative SQLite Storage for Hangfire</Description>
 		<PackageReleaseNotes>
-			0.4.3
-			- Upgrade projects to .NET 8.0 (LTS).
-			- Update dependencies (Hangfire 1.8.23, Newtonsoft.Json 13.0.4).
-			- Explicitly referenced SQLitePCLRaw.bundle_green 2.1.11 to resolve NETSDK1206 RID-related warnings.
-			- Support for modern Hangfire 1.8 background process registration (GetStorageWideProcesses).
-		</PackageReleaseNotes>
+      0.4.3 (thanks to @itsC-Ramesh)
+      - Upgrade projects to .NET 8.0 (LTS).
+      - Update dependencies (Hangfire 1.8.23, Newtonsoft.Json 13.0.4).
+      - Explicitly referenced SQLitePCLRaw.bundle_green 2.1.11 to resolve NETSDK1206 RID-related warnings.
+      - Support for modern Hangfire 1.8 background process registration (GetStorageWideProcesses).
+    </PackageReleaseNotes>
 	</PropertyGroup>
 	<ItemGroup>
 		<None Include="..\..\..\LICENSE">


### PR DESCRIPTION
      0.4.3 (thanks to @itsC-Ramesh)
      - Upgrade projects to .NET 8.0 (LTS).
      - Update dependencies (Hangfire 1.8.23, Newtonsoft.Json 13.0.4).
      - Explicitly referenced SQLitePCLRaw.bundle_green 2.1.11 to resolve NETSDK1206 RID-related warnings.
      - Support for modern Hangfire 1.8 background process registration (GetStorageWideProcesses).